### PR TITLE
Add project name support in deployment SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Set your API key in the environment:
 
 ```bash
 export CELESTO_API_KEY="your-key"
+export CELESTO_PROJECT_NAME="your-project-name"
 ```
 
 ## CLI
 
 ```bash
-celesto deploy
+celesto deploy --project "My Project"
 celesto ls
 celesto a2a get-card --agent http://localhost:8000
 ```

--- a/src/celesto/deployment.py
+++ b/src/celesto/deployment.py
@@ -111,7 +111,7 @@ def deploy(
         None,
         "--project",
         "-p",
-        help="Celesto project name (or set CELESTO_PROJECT_NAME env var)",
+        help="Celesto project name (optional; defaults to first project)",
     ),
     api_key: Optional[str] = typer.Option(
         None,
@@ -134,10 +134,6 @@ def deploy(
     final_api_key = _get_api_key(api_key, ignore_env_file, "CELESTO_API_KEY")
 
     resolved_project_name = project_name or os.environ.get("CELESTO_PROJECT_NAME")
-    if not resolved_project_name:
-        console.print("❌ [bold red]Error:[/bold red] Project name not found.")
-        console.print("Provide it via [bold]--project[/bold] or set [bold]CELESTO_PROJECT_NAME[/bold].")
-        raise typer.Exit(1)
 
     # Validate folder path
     folder_path = Path(folder).resolve()

--- a/src/celesto/deployment.py
+++ b/src/celesto/deployment.py
@@ -107,6 +107,12 @@ def deploy(
         "-e",
         help='Environment variables as comma-separated key=value pairs (e.g., "API_KEY=xyz,DEBUG=true")',
     ),
+    project_name: Optional[str] = typer.Option(
+        None,
+        "--project",
+        "-p",
+        help="Celesto project name (or set CELESTO_PROJECT_NAME env var)",
+    ),
     api_key: Optional[str] = typer.Option(
         None,
         "--api-key",
@@ -126,6 +132,12 @@ def deploy(
     """
     # Get API key
     final_api_key = _get_api_key(api_key, ignore_env_file, "CELESTO_API_KEY")
+
+    resolved_project_name = project_name or os.environ.get("CELESTO_PROJECT_NAME")
+    if not resolved_project_name:
+        console.print("❌ [bold red]Error:[/bold red] Project name not found.")
+        console.print("Provide it via [bold]--project[/bold] or set [bold]CELESTO_PROJECT_NAME[/bold].")
+        raise typer.Exit(1)
 
     # Validate folder path
     folder_path = Path(folder).resolve()
@@ -151,7 +163,11 @@ def deploy(
 
         client = CelestoSDK(final_api_key)
         result = client.deployment.deploy(
-            folder=folder_path, name=name, description=description, envs=env_dict
+            folder=folder_path,
+            name=name,
+            description=description,
+            envs=env_dict,
+            project_name=resolved_project_name,
         )
         console.print("✅ [bold green]Deployment successful![/bold green]")
 


### PR DESCRIPTION
- Updated README to include project name configuration.
- Enhanced deploy function to accept a project name via command line or environment variable.
- Implemented project ID resolution based on project name in the SDK client.
- Adjusted deployment methods to incorporate project ID for deployments.