### PR TITLE
Refine SDK: cpus/memory params + README focused on computers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/celesto.svg)](https://pypi.org/project/celesto/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Sandboxed cloud computers for AI agents. Spin up isolated Ubuntu VMs in seconds, run commands, and tear them down -- all from Python or the CLI.
+Sandboxed cloud computers for AI agents. Spin up isolated computers in seconds, run workflows/commands or long running agents -- all from Python or the CLI.
 
 ```bash
 pip install celesto
@@ -17,8 +17,8 @@ from celesto.sdk import CelestoSDK
 
 with CelestoSDK() as client:
     # Spin up a sandbox
-    computer = client.computers.create(vcpus=2, ram_mb=2048)
-    print(f"VM ready: {computer['id']}")
+    computer = client.computers.create(cpus=2, memory=2048)
+    print(f"Computer ready: {computer['id']}")
 
     # Run anything
     result = client.computers.exec(computer["id"], "uname -a")
@@ -41,7 +41,7 @@ celesto computer delete <id>
 
 ## Why Celesto?
 
-- **Fast** -- VMs boot in seconds via Firecracker microVMs
+- **Fast** -- computers boot in seconds via Firecracker microVMs
 - **Isolated** -- every sandbox is a real VM, not a container
 - **Simple** -- three API calls: create, exec, delete
 - **Built for agents** -- give your AI full computer access without risking your host
@@ -70,13 +70,12 @@ client = CelestoSDK(api_key="your-api-key")
 
 ## Computers API
 
-### Create a sandbox
+### Create a computer
 
 ```python
 computer = client.computers.create(
-    vcpus=2,        # 1-16 CPUs
-    ram_mb=2048,    # 512-32768 MB
-    image="ubuntu-desktop-24.04"
+    cpus=2,        # 1-16 CPUs
+    memory=2048,   # 512-32768 MB
 )
 ```
 
@@ -94,7 +93,7 @@ Set a timeout (default 30s, max 300s):
 result = client.computers.exec(computer["id"], "long-running-script.sh", timeout=120)
 ```
 
-### Lifecycle management
+### Lifecycle
 
 ```python
 client.computers.stop(computer_id)     # pause the VM
@@ -102,7 +101,7 @@ client.computers.start(computer_id)    # resume it
 client.computers.delete(computer_id)   # destroy it
 ```
 
-### List sandboxes
+### List computers
 
 ```python
 result = client.computers.list()
@@ -110,41 +109,15 @@ for vm in result["computers"]:
     print(f"{vm['id']}: {vm['status']}")
 ```
 
-## CLI Reference
+## CLI
 
-```bash
-celesto computer create [--cpus N] [--memory MB]    # create a sandbox
-celesto computer list                                # list all sandboxes
-celesto computer run <id> "command"                  # execute a command
-celesto computer ssh <id>                            # interactive SSH session
-celesto computer delete <id> [--force]               # destroy a sandbox
-```
-
-## Agent Deployment
-
-Deploy AI agents as serverless endpoints with automatic scaling.
-
-```python
-from celesto.sdk import CelestoSDK
-from pathlib import Path
-
-with CelestoSDK() as client:
-    result = client.deployment.deploy(
-        folder=Path("./my-agent"),
-        name="my-agent",
-        description="My AI assistant",
-        envs={"OPENAI_API_KEY": "sk-..."},
-        project_name="My Project"
-    )
-    print(f"Status: {result['status']}")
-```
-
-```bash
-celesto deploy --project "My Project"
-celesto ls                              # list deployments
-```
-
-Exclude files from the deployment bundle with a `.celestoignore` file (same syntax as `.gitignore`).
+| Command | Description |
+|---|---|
+| `celesto computer create [--cpus N] [--memory MB]` | Create a computer |
+| `celesto computer list` | List all computers |
+| `celesto computer run <id> "command"` | Execute a command |
+| `celesto computer ssh <id>` | Interactive shell |
+| `celesto computer delete <id> [--force]` | Destroy a computer |
 
 ## Error Handling
 
@@ -164,30 +137,6 @@ except CelestoAuthenticationError:
     print("Bad API key -- check https://celesto.ai > Settings > Security")
 except CelestoRateLimitError as e:
     print(f"Rate limited. Retry in {e.retry_after}s")
-```
-
-## Advanced
-
-### Custom API endpoint
-
-```python
-client = CelestoSDK(base_url="https://custom-api.example.com/v1")
-```
-
-Or via environment:
-
-```bash
-export CELESTO_BASE_URL="https://custom-api.example.com/v1"
-```
-
-### Resource cleanup
-
-Use the context manager to ensure connections are closed:
-
-```python
-with CelestoSDK() as client:
-    # ... your code ...
-    pass  # automatically cleaned up
 ```
 
 ## Links

--- a/src/celesto/sdk/client.py
+++ b/src/celesto/sdk/client.py
@@ -794,7 +794,7 @@ class Computers(_BaseClient):
 
     Example:
         >>> with CelestoSDK() as client:
-        ...     computer = client.computers.create(vcpus=2, ram_mb=2048)
+        ...     computer = client.computers.create(cpus=2, memory=2048)
         ...     result = client.computers.exec(computer["id"], "uname -a")
         ...     print(result["stdout"])
         ...     client.computers.delete(computer["id"])
@@ -803,24 +803,24 @@ class Computers(_BaseClient):
     def create(
         self,
         *,
-        vcpus: int = 1,
-        ram_mb: int = 1024,
+        cpus: int = 1,
+        memory: int = 1024,
         image: str = "ubuntu-desktop-24.04",
     ) -> dict[str, Any]:
         """Create a new sandboxed computer.
 
         Args:
-            vcpus: Number of virtual CPUs (1-16).
-            ram_mb: Memory in MB (512-32768).
+            cpus: Number of virtual CPUs (1-16).
+            memory: Memory in MB (512-32768).
             image: OS image name.
 
         Returns:
-            Computer info dict with id, status, vcpus, ram_mb, etc.
+            Computer info dict with id, status, cpus, memory, etc.
         """
         return self._request(
             "POST",
             "/computers",
-            json_body={"vcpus": vcpus, "ram_mb": ram_mb, "image": image},
+            json_body={"vcpus": cpus, "ram_mb": memory, "image": image},
         )
 
     def list(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Rename `vcpus`→`cpus`, `ram_mb`→`memory` in `Computers.create()` for a cleaner API
- Backend still receives `vcpus`/`ram_mb` (mapped in the SDK)
- README rewritten: dropped Agent Deployment and Advanced sections, computers-only focus
- Updated description: "Sandboxed cloud computers for AI agents. Spin up isolated computers in seconds, run workflows/commands or long running agents -- all from Python or the CLI."

## Test plan
- [ ] `client.computers.create(cpus=2, memory=2048)` works
- [ ] README renders correctly on GitHub
- [ ] CLI `celesto computer create --cpus 2 --memory 2048` still works (uses CLI params, not SDK params)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation & API Changes

* **Documentation**
  * Updated product documentation with revised terminology and examples
  * Simplified CLI reference with streamlined subcommand table
  * Removed deprecated sections from documentation

* **API Changes**
  * Updated `Computers.create()` method parameters: `vcpus` → `cpus`, `ram_mb` → `memory`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->