### PR TITLE
feat: surface computer error state on terminal disconnect

### DIFF
--- a/src/celesto/computer.py
+++ b/src/celesto/computer.py
@@ -257,7 +257,20 @@ def ssh_to_computer(
                     os.write(sys.stdout.fileno(), msg)
         except websockets.exceptions.ConnectionClosed as e:
             if e.rcvd and e.rcvd.code != 1000:
-                console.print(f"\n[red]Connection closed: code={e.rcvd.code} reason={e.rcvd.reason}[/red]")
+                console.print(f"\n[red]Connection lost (code={e.rcvd.code}).[/red]")
+                # Check if computer entered error state (e.g. host spot-interrupted)
+                try:
+                    with _get_client(api_key) as check_client:
+                        info = check_client.computers.get(resolved_id)
+                        comp_status = info.get("status")
+                        if comp_status == "error":
+                            last_err = info.get("last_error", "unknown")
+                            console.print(f"[red]Computer error: {last_err}[/red]")
+                            console.print("[dim]Create a new computer with: celesto computer create[/dim]")
+                        elif comp_status == "running":
+                            console.print(f"[yellow]Computer is still running. Reconnect with: celesto computer ssh {computer_id}[/yellow]")
+                except Exception:
+                    pass
         except OSError:
             pass
         finally:

--- a/src/celesto/computer.py
+++ b/src/celesto/computer.py
@@ -13,6 +13,7 @@ from typing_extensions import Annotated
 
 from .deployment import _get_api_key
 from .sdk.client import CelestoSDK
+from .sdk.exceptions import CelestoAuthenticationError, CelestoNetworkError, CelestoNotFoundError
 
 app = typer.Typer(help="Create, manage, and connect to sandboxed computers.")
 console = Console()
@@ -269,8 +270,21 @@ def ssh_to_computer(
                             console.print("[dim]Create a new computer with: celesto computer create[/dim]")
                         elif comp_status == "running":
                             console.print(f"[yellow]Computer is still running. Reconnect with: celesto computer ssh {computer_id}[/yellow]")
-                except Exception:
-                    pass
+                        elif comp_status in ("stopped", "stopping"):
+                            console.print(f"[yellow]Computer is {comp_status}. Start it with: celesto computer start {computer_id}[/yellow]")
+                        elif comp_status in ("deleted", "deleting"):
+                            console.print("[red]Computer has been deleted.[/red]")
+                            console.print("[dim]Create a new computer with: celesto computer create[/dim]")
+                        elif comp_status in ("creating", "starting"):
+                            console.print(f"[yellow]Computer is {comp_status}. Wait a moment and retry: celesto computer ssh {computer_id}[/yellow]")
+                        else:
+                            console.print(f"[yellow]Computer status: {comp_status}[/yellow]")
+                except (CelestoNotFoundError,):
+                    console.print("[red]Computer not found — it may have been deleted.[/red]")
+                except (CelestoAuthenticationError, CelestoNetworkError) as exc:
+                    console.print(f"[dim]Could not check computer status: {exc}[/dim]")
+                except Exception as exc:
+                    console.print(f"[dim]Could not check computer status: {exc}[/dim]")
         except OSError:
             pass
         finally:


### PR DESCRIPTION
## Summary
- When the terminal WebSocket drops unexpectedly, check computer status via the API
- If computer is in ERROR state (host was spot-interrupted), show `last_error` and suggest `celesto computer create`
- If computer is still RUNNING, suggest reconnecting with `celesto computer ssh`
- No more silent "Disconnected" when the host dies

**Companion PRs:**
- Backend: CelestoAI/celesto-backend (cleanup task + draining endpoint)
- Agent: CelestoAI/celesto-agent#4 (spot watcher + graceful shutdown)

## Test plan
- [ ] Open terminal session, kill host agent mid-session — verify error message appears
- [ ] Open terminal session, disconnect network briefly — verify "still running, reconnect" message
- [ ] Normal Ctrl+] disconnect should still show clean "Disconnected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection-loss handling and messages. When a connection drops unexpectedly, the tool now checks the computer's status and provides tailored guidance for states like running, stopped, creating/starting, deleting/deleted, or error (including suggested next steps).
  * Enhanced error handling for status checks so network/auth failures or missing records produce concise, user-friendly notices instead of noisy errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->