### PR TITLE
Serialize OpenAI Agents sandbox operations

### DIFF
--- a/src/celesto/integrations/openai_agents/hosted.py
+++ b/src/celesto/integrations/openai_agents/hosted.py
@@ -57,6 +57,7 @@ class CelestoSandboxSession(CommandBackedSession):
         self.state = state
         self._client = client
         self._running = False
+        self._command_lock = asyncio.Lock()
 
     @classmethod
     def from_state(
@@ -95,12 +96,13 @@ class CelestoSandboxSession(CommandBackedSession):
                 "No Celesto computer is ready yet. Start the session with "
                 "`async with session:` before running commands."
             )
-        return await asyncio.to_thread(
-            self._client.computers.exec,
-            self.state.computer_id,
-            command,
-            timeout=timeout_seconds(timeout),
-        )
+        async with self._command_lock:
+            return await asyncio.to_thread(
+                self._client.computers.exec,
+                self.state.computer_id,
+                command,
+                timeout=timeout_seconds(timeout),
+            )
 
     async def _delete_backend(self) -> None:
         if self.state.computer_id is None:

--- a/src/celesto/integrations/openai_agents/smolvm.py
+++ b/src/celesto/integrations/openai_agents/smolvm.py
@@ -65,6 +65,7 @@ class SmolVMSandboxSession(CommandBackedSession):
         self.state = state
         self._vm: Any | None = None
         self._running = False
+        self._command_lock = asyncio.Lock()
 
     @classmethod
     def from_state(cls, state: SmolVMSandboxSessionState) -> "SmolVMSandboxSession":
@@ -111,11 +112,12 @@ class SmolVMSandboxSession(CommandBackedSession):
 
     async def _run_guest(self, command: str, *, timeout: float | None = None) -> dict[str, Any]:
         vm = self._connect_or_create_vm()
-        result = await asyncio.to_thread(
-            vm.run,
-            command,
-            timeout=timeout_seconds(timeout),
-        )
+        async with self._command_lock:
+            result = await asyncio.to_thread(
+                vm.run,
+                command,
+                timeout=timeout_seconds(timeout),
+            )
         return {"exit_code": result.exit_code, "stdout": result.stdout, "stderr": result.stderr}
 
     async def _resolve_exposed_port(self, port: int) -> ExposedPortEndpoint:
@@ -138,7 +140,8 @@ class SmolVMSandboxSession(CommandBackedSession):
             tmp_path = Path(tmp.name)
         try:
             vm = self._connect_or_create_vm()
-            await asyncio.to_thread(vm.upload_file, tmp_path, workspace_path.as_posix())
+            async with self._command_lock:
+                await asyncio.to_thread(vm.upload_file, tmp_path, workspace_path.as_posix())
         finally:
             tmp_path.unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary

- serialize command and file operations inside OpenAI Agents sandbox sessions
- avoid concurrent SmolVM SSH/SFTP calls during manifest setup\n- update the SmolVM install hint to the current OpenAI Agents extra\n\n## Validation
- `uv run ruff check src/celesto/integrations tests/test_openai_agents_integration.py`\n- `uv run pytest tests/test_sdk.py tests/test_openai_agents_integration.py`\n- ran `uv run python examples/openai-agents-sdk/harness_outside_sandbox.py`; setup reached the model call and stopped because `OPENAI_API_KEY` is not set in this shell