### PR TITLE
Add sandbox template support across Python and Node SDKs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,35 @@ uv run pytest
 - Avoid placeholders like `# ... rest of code ...`.
 - Prefer clear, explicit error messages.
 - Maintain backwards compatibility where possible (public SDK/CLI).
+
+## CLI Design
+
+- New CLI commands should follow a **NOUN-VERB** structure: `celesto <noun> <verb>`.
+- The noun names the resource, such as a computer, deployment, connection, or template.
+- The verb names the action, such as `create`, `list`, `start`, `stop`, or `delete`.
+- When adding a new resource, register it as a top-level subcommand and put its actions underneath instead of overloading a global verb.
+- Keep backwards compatibility for existing public CLI commands. Known exception: `celesto computer templates` is accepted for listing computer templates.
+
+## User-Facing Writing Principles
+
+- Follow progressive disclosure of complexity.
+- Lead with outcomes, not implementation details.
+- The first paragraph of every documentation page should be plain English with no jargon.
+- Assume the reader may be a beginner engineer or a non-developer.
+- Do not assume prior knowledge.
+- Explain what the user can do and why it matters before explaining how it works.
+- Do not introduce a new concept unless the page truly needs it.
+- If a technical term is necessary, explain it immediately in simple language.
+- Prefer short, concrete sentences over dense explanations.
+
+## User-Facing Errors and Warnings
+
+Error and warning messages are UX, not stack traces. Every user-facing message
+in CLI output, panels, JSON `error` payloads, and JSON `warnings` entries should:
+
+- State the fact in plain English.
+- Avoid internal vocabulary when possible, even if that vocabulary appears in flag names.
+- Name the recovery with the exact command or API call the user can run.
+- Include the actual resource name or ID when available.
+- Stay short: one sentence is best, two sentences is acceptable.
+- Skip consequences that cannot be guaranteed in the current state.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ from celesto import Celesto
 
 client = Celesto()
 
-computer = client.computers.create(cpus=2, memory=2048)
+computer = client.computers.create(template_id="coding-agent")
 print(f"Computer ready: {computer['name']}")
 
 result = client.computers.exec(computer["id"], "uname -a")
@@ -38,7 +38,7 @@ import { Celesto } from "@celestoai/sdk";
 
 const celesto = new Celesto({ token: process.env.CELESTO_API_KEY });
 
-const computer = await celesto.computers.create({ cpus: 2, memory: 2048 });
+const computer = await celesto.computers.create({ templateId: "coding-agent" });
 console.log(`Computer ready: ${computer.name}`);
 
 const result = await celesto.computers.exec(computer.id, "uname -a");
@@ -52,7 +52,7 @@ await celesto.computers.delete(computer.id);
 ```bash
 export CELESTO_API_KEY="your-api-key"
 
-celesto computer create --cpus 2 --memory 2048
+celesto computer create --template coding-agent
 celesto computer run einstein "ls -la"
 celesto computer ssh einstein       # interactive shell
 celesto computer delete einstein
@@ -117,7 +117,9 @@ agent = SandboxAgent(
 )
 
 client = CelestoSandboxClient()
-session = await client.create(options=CelestoSandboxClientOptions(cpus=2, memory=2048))
+session = await client.create(
+    options=CelestoSandboxClientOptions(template_id="coding-agent")
+)
 try:
     async with session:
         result = await Runner.run(
@@ -138,8 +140,21 @@ when you want the same agent flow to run on a local SmolVM sandbox.
 ### Create
 
 ```python
-computer = client.computers.create(cpus=2, memory=2048)
+computer = client.computers.create(
+    template_id="coding-agent",
+    cpus=2,
+    memory=2048,
+    disk_size_mb=15360,
+)
 print(computer["name"])  # e.g., "einstein"
+```
+
+Omit CPU, memory, or disk fields to use the selected template defaults.
+
+```python
+templates = client.computers.list_templates()
+for template in templates:
+    print(template["id"], template["default_ram_mb"])
 ```
 
 ### Execute commands
@@ -170,7 +185,8 @@ for vm in result["computers"]:
 
 | Command | Description |
 |---|---|
-| `celesto computer create [--cpus N] [--memory MB]` | Create a computer |
+| `celesto computer create [--template ID] [--cpus N] [--memory MB] [--disk-size-mb MB]` | Create a computer |
+| `celesto computer templates` | List sandbox templates |
 | `celesto computer list` | List all computers |
 | `celesto computer run <name> "command"` | Execute a command |
 | `celesto computer ssh <name>` | Interactive shell |
@@ -184,7 +200,8 @@ All commands support `--json` for machine-readable output:
 
 ```bash
 celesto computer list --json
-celesto computer create --cpus 2 --memory 2048 --json
+celesto computer templates --json
+celesto computer create --template coding-agent --disk-size-mb 15360 --json
 celesto computer run einstein "uname -a" --json
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ when you want the same agent flow to run on a local SmolVM sandbox.
 
 ## Computers API
 
+Templates are ready-made computer setups. Choose one when you want a computer
+that already has the tools your agent needs.
+
 ### Create
 
 ```python
@@ -186,7 +189,7 @@ for vm in result["computers"]:
 | Command | Description |
 |---|---|
 | `celesto computer create [--template ID] [--cpus N] [--memory MB] [--disk-size-mb MB]` | Create a computer |
-| `celesto computer templates` | List sandbox templates |
+| `celesto computer templates` | List computer templates |
 | `celesto computer list` | List all computers |
 | `celesto computer run <name> "command"` | Execute a command |
 | `celesto computer ssh <name>` | Interactive shell |

--- a/js/README.md
+++ b/js/README.md
@@ -22,7 +22,7 @@ const celesto = new Celesto({
 });
 
 // Computers
-const computer = await celesto.computers.create({ cpus: 2, memory: 2048 });
+const computer = await celesto.computers.create({ templateId: "coding-agent" });
 const result = await celesto.computers.exec(computer.id, "uname -a");
 console.log(result.stdout);
 await celesto.computers.delete(computer.id);
@@ -34,9 +34,10 @@ await celesto.computers.delete(computer.id);
 
 ```ts
 const computer = await celesto.computers.create({
+  templateId: "coding-agent",
   cpus: 2,
   memory: 2048,
-  image: "ubuntu-desktop-24.04",
+  diskSizeMb: 15360,
 });
 
 await celesto.computers.stop(computer.id);
@@ -44,6 +45,15 @@ await celesto.computers.start(computer.id);
 await celesto.computers.delete(computer.id);
 
 const { computers, count } = await celesto.computers.list();
+```
+
+Omit CPU, memory, or disk fields to use the selected template defaults.
+
+```ts
+const templates = await celesto.computers.listTemplates();
+for (const template of templates) {
+  console.log(template.id, template.defaultRamMb);
+}
 ```
 
 ### Running commands

--- a/js/README.md
+++ b/js/README.md
@@ -1,6 +1,9 @@
 # @celestoai/sdk
 
-Node-only TypeScript SDK for the [Celesto](https://celesto.ai) platform. Covers:
+Use this package to create Celesto computers from Node.js apps. Your code can
+start a computer, run commands in it, and delete it when the work is done.
+
+It includes:
 
 - **Computers** (`/v1/computers`) — create, manage, and interact with sandboxed virtual machines
 - **Gatekeeper** (`/v1/gatekeeper`) — delegated access to user resources
@@ -29,6 +32,9 @@ await celesto.computers.delete(computer.id);
 ```
 
 ## Computers
+
+Templates are ready-made computer setups. Choose one when you want a computer
+that already has the tools your agent needs.
 
 ### Lifecycle
 

--- a/js/src/computers/client.ts
+++ b/js/src/computers/client.ts
@@ -8,6 +8,7 @@ import {
   ComputerStatus,
   CreateComputerParams,
   ExecParams,
+  SandboxTemplateInfo,
   TerminalConnectionInfo,
 } from "./types";
 
@@ -22,7 +23,10 @@ interface ComputerInfoWire {
   status: ComputerStatus;
   vcpus: number;
   ram_mb: number;
+  disk_size_mb: number;
   image: string;
+  template_id: string;
+  template_version?: string | null;
   connection?: ComputerConnectionInfoWire | null;
   last_error?: string | null;
   created_at: string;
@@ -38,6 +42,17 @@ interface ComputerExecResponseWire {
   exit_code: number;
   stdout: string;
   stderr: string;
+}
+
+interface SandboxTemplateInfoWire {
+  id: string;
+  display_name: string;
+  description: string;
+  default_vcpus: number;
+  default_ram_mb: number;
+  default_disk_size_mb: number;
+  version?: string | null;
+  experimental: boolean;
 }
 
 const toConnection = (
@@ -62,7 +77,10 @@ const toComputerInfo = (payload: ComputerInfoWire): ComputerInfo => ({
   status: payload.status,
   vcpus: payload.vcpus,
   ramMb: payload.ram_mb,
+  diskSizeMb: payload.disk_size_mb,
   image: payload.image,
+  templateId: payload.template_id,
+  templateVersion: payload.template_version ?? null,
   connection: toConnection(payload.connection),
   lastError: payload.last_error ?? null,
   createdAt: payload.created_at,
@@ -74,6 +92,49 @@ const toExecResponse = (payload: ComputerExecResponseWire): ComputerExecResponse
   stdout: payload.stdout,
   stderr: payload.stderr,
 });
+
+const toSandboxTemplateInfo = (payload: SandboxTemplateInfoWire): SandboxTemplateInfo => ({
+  id: payload.id,
+  displayName: payload.display_name,
+  description: payload.description,
+  defaultVcpus: payload.default_vcpus,
+  defaultRamMb: payload.default_ram_mb,
+  defaultDiskSizeMb: payload.default_disk_size_mb,
+  version: payload.version ?? null,
+  experimental: payload.experimental,
+});
+
+const buildCreateComputerBody = (params: CreateComputerParams): Record<string, unknown> => {
+  if (params.cpus !== undefined && params.vcpus !== undefined && params.cpus !== params.vcpus) {
+    throw new Error("Pass either cpus or vcpus, not both.");
+  }
+  if (params.memory !== undefined && params.ramMb !== undefined && params.memory !== params.ramMb) {
+    throw new Error("Pass either memory or ramMb, not both.");
+  }
+
+  const body: Record<string, unknown> = {};
+  const vcpus = params.vcpus ?? params.cpus;
+  const ramMb = params.ramMb ?? params.memory;
+  if (vcpus !== undefined) {
+    body.vcpus = vcpus;
+  }
+  if (ramMb !== undefined) {
+    body.ram_mb = ramMb;
+  }
+  if (params.diskSizeMb !== undefined) {
+    body.disk_size_mb = params.diskSizeMb;
+  }
+  if (params.image !== undefined) {
+    body.image = params.image;
+  }
+  if (params.templateId !== undefined) {
+    body.template_id = params.templateId;
+  }
+  if (params.templateVersion !== undefined) {
+    body.template_version = params.templateVersion;
+  }
+  return body;
+};
 
 const computersPath = (path: string): string => `/v1/computers${path}`;
 
@@ -92,7 +153,7 @@ const pickOverrides = (options?: RequestOverrides): RequestOverrides => ({
  * @example
  * ```ts
  * const celesto = new Celesto({ token: process.env.CELESTO_API_KEY });
- * const computer = await celesto.computers.create({ cpus: 2, memory: 2048 });
+ * const computer = await celesto.computers.create({ templateId: "coding-agent" });
  * const result = await celesto.computers.exec(computer.id, "uname -a");
  * console.log(result.stdout);
  * await celesto.computers.delete(computer.id);
@@ -110,14 +171,20 @@ export class ComputersClient {
     const data = await request<ComputerInfoWire>(ctx, {
       method: "POST",
       path: computersPath(""),
-      body: {
-        vcpus: params.cpus ?? 1,
-        ram_mb: params.memory ?? 1024,
-        image: params.image ?? "ubuntu-desktop-24.04",
-      },
+      body: buildCreateComputerBody(params),
       ...pickOverrides(options),
     });
     return toComputerInfo(data);
+  }
+
+  async listTemplates(options?: RequestOverrides): Promise<SandboxTemplateInfo[]> {
+    const ctx = buildRequestContext(this.config);
+    const data = await request<SandboxTemplateInfoWire[]>(ctx, {
+      method: "GET",
+      path: computersPath("/templates"),
+      ...pickOverrides(options),
+    });
+    return data.map(toSandboxTemplateInfo);
   }
 
   async list(options?: RequestOverrides): Promise<ComputerListResponse> {

--- a/js/src/computers/client.ts
+++ b/js/src/computers/client.ts
@@ -106,10 +106,10 @@ const toSandboxTemplateInfo = (payload: SandboxTemplateInfoWire): SandboxTemplat
 
 const buildCreateComputerBody = (params: CreateComputerParams): Record<string, unknown> => {
   if (params.cpus !== undefined && params.vcpus !== undefined && params.cpus !== params.vcpus) {
-    throw new Error("Pass either cpus or vcpus, not both.");
+    throw new Error("cpus and vcpus must have the same value when both are provided.");
   }
   if (params.memory !== undefined && params.ramMb !== undefined && params.memory !== params.ramMb) {
-    throw new Error("Pass either memory or ramMb, not both.");
+    throw new Error("memory and ramMb must have the same value when both are provided.");
   }
 
   const body: Record<string, unknown> = {};

--- a/js/src/computers/index.ts
+++ b/js/src/computers/index.ts
@@ -7,5 +7,6 @@ export type {
   ComputerStatus,
   CreateComputerParams,
   ExecParams,
+  SandboxTemplateInfo,
   TerminalConnectionInfo,
 } from "./types";

--- a/js/src/computers/types.ts
+++ b/js/src/computers/types.ts
@@ -4,6 +4,8 @@ export type ComputerStatus =
   | "stopping"
   | "stopped"
   | "starting"
+  | "restoring"
+  | "restorable"
   | "deleting"
   | "deleted"
   | "error";
@@ -19,7 +21,10 @@ export interface ComputerInfo {
   status: ComputerStatus;
   vcpus: number;
   ramMb: number;
+  diskSizeMb: number;
   image: string;
+  templateId: string;
+  templateVersion?: string | null;
   connection?: ComputerConnectionInfo;
   lastError?: string | null;
   createdAt: string;
@@ -37,13 +42,34 @@ export interface ComputerExecResponse {
   stderr: string;
 }
 
+export interface SandboxTemplateInfo {
+  id: string;
+  displayName: string;
+  description: string;
+  defaultVcpus: number;
+  defaultRamMb: number;
+  defaultDiskSizeMb: number;
+  version?: string | null;
+  experimental: boolean;
+}
+
 export interface CreateComputerParams {
-  /** Number of virtual CPUs (1-16). Defaults to 1. */
+  /** Number of virtual CPUs (1-16). Alias for vcpus. */
   cpus?: number;
-  /** Memory in MB (512-32768). Defaults to 1024. */
+  /** Number of virtual CPUs (1-16). */
+  vcpus?: number;
+  /** Memory in MB (512-32768). Alias for ramMb. */
   memory?: number;
-  /** OS image name. Defaults to "ubuntu-desktop-24.04". */
+  /** Memory in MB (512-32768). */
+  ramMb?: number;
+  /** Disk size in MB (512-51200). */
+  diskSizeMb?: number;
+  /** Legacy OS image selector. */
   image?: string;
+  /** Sandbox template id, such as "scratch" or "coding-agent". */
+  templateId?: string;
+  /** Optional immutable template version. */
+  templateVersion?: string;
 }
 
 export interface ExecParams {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -27,6 +27,7 @@ export type {
   ComputerStatus,
   CreateComputerParams,
   ExecParams,
+  SandboxTemplateInfo,
   TerminalConnectionInfo,
 } from "./computers";
 export type { ClientConfig, RequestOverrides } from "./core/config";

--- a/js/tests/computers.test.ts
+++ b/js/tests/computers.test.ts
@@ -122,11 +122,11 @@ describe("ComputersClient", () => {
 
     await assert.rejects(
       () => client.create({ cpus: 1, vcpus: 2 }),
-      /cpus or vcpus/i,
+      /cpus and vcpus must have the same value/i,
     );
     await assert.rejects(
       () => client.create({ memory: 1024, ramMb: 2048 }),
-      /memory or ramMb/i,
+      /memory and ramMb must have the same value/i,
     );
   });
 

--- a/js/tests/computers.test.ts
+++ b/js/tests/computers.test.ts
@@ -48,7 +48,7 @@ const makeConfig = (fetchMock: typeof fetch): ClientConfig => ({
 });
 
 describe("ComputersClient", () => {
-  it("create() sends vcpus/ram_mb wire fields and unwraps snake_case response", async () => {
+  it("create() sends explicit resource/template fields and unwraps snake_case response", async () => {
     const { fetch, calls } = makeFetchMock(() => ({
       status: 201,
       body: {
@@ -57,7 +57,10 @@ describe("ComputersClient", () => {
         status: "creating",
         vcpus: 2,
         ram_mb: 2048,
+        disk_size_mb: 15360,
         image: "ubuntu-desktop-24.04",
+        template_id: "coding-agent",
+        template_version: "latest",
         created_at: "2026-04-16T00:00:00Z",
         last_error: null,
         stopped_at: null,
@@ -65,7 +68,13 @@ describe("ComputersClient", () => {
     }));
     const client = new ComputersClient(makeConfig(fetch));
 
-    const result = await client.create({ cpus: 2, memory: 2048 });
+    const result = await client.create({
+      cpus: 2,
+      memory: 2048,
+      diskSizeMb: 15360,
+      templateId: "coding-agent",
+      templateVersion: "latest",
+    });
 
     assert.equal(calls.length, 1);
     assert.equal(calls[0]!.method, "POST");
@@ -73,15 +82,20 @@ describe("ComputersClient", () => {
     assert.deepEqual(calls[0]!.body, {
       vcpus: 2,
       ram_mb: 2048,
-      image: "ubuntu-desktop-24.04",
+      disk_size_mb: 15360,
+      template_id: "coding-agent",
+      template_version: "latest",
     });
     assert.equal(calls[0]!.headers["authorization"], "Bearer test-token");
     assert.equal(result.id, "cmp_abc");
     assert.equal(result.ramMb, 2048);
+    assert.equal(result.diskSizeMb, 15360);
+    assert.equal(result.templateId, "coding-agent");
+    assert.equal(result.templateVersion, "latest");
     assert.equal(result.lastError, null);
   });
 
-  it("create() applies defaults when no params are provided", async () => {
+  it("create() leaves defaults to the backend when no params are provided", async () => {
     const { fetch, calls } = makeFetchMock(() => ({
       status: 201,
       body: {
@@ -89,8 +103,10 @@ describe("ComputersClient", () => {
         name: "d",
         status: "creating",
         vcpus: 1,
-        ram_mb: 1024,
+        ram_mb: 512,
+        disk_size_mb: 7168,
         image: "ubuntu-desktop-24.04",
+        template_id: "scratch",
         created_at: "2026-04-16T00:00:00Z",
       },
     }));
@@ -98,11 +114,20 @@ describe("ComputersClient", () => {
 
     await client.create();
 
-    assert.deepEqual(calls[0]!.body, {
-      vcpus: 1,
-      ram_mb: 1024,
-      image: "ubuntu-desktop-24.04",
-    });
+    assert.deepEqual(calls[0]!.body, {});
+  });
+
+  it("create() rejects conflicting aliases", async () => {
+    const client = new ComputersClient(makeConfig(async () => new Response()));
+
+    await assert.rejects(
+      () => client.create({ cpus: 1, vcpus: 2 }),
+      /cpus or vcpus/i,
+    );
+    await assert.rejects(
+      () => client.create({ memory: 1024, ramMb: 2048 }),
+      /memory or ramMb/i,
+    );
   });
 
   it("list() maps each computer through the wire transform", async () => {
@@ -116,7 +141,9 @@ describe("ComputersClient", () => {
             status: "running",
             vcpus: 1,
             ram_mb: 1024,
+            disk_size_mb: 7168,
             image: "ubuntu-desktop-24.04",
+            template_id: "scratch",
             created_at: "2026-04-16T00:00:00Z",
             connection: { ssh: "user@host", access_url: "https://a" },
           },
@@ -126,7 +153,9 @@ describe("ComputersClient", () => {
             status: "stopped",
             vcpus: 4,
             ram_mb: 8192,
+            disk_size_mb: 15360,
             image: "ubuntu-desktop-24.04",
+            template_id: "browser-agent",
             created_at: "2026-04-16T00:00:00Z",
             stopped_at: "2026-04-16T01:00:00Z",
           },
@@ -142,7 +171,36 @@ describe("ComputersClient", () => {
     assert.equal(result.computers.length, 2);
     assert.equal(result.computers[0]!.connection?.ssh, "user@host");
     assert.equal(result.computers[0]!.connection?.accessUrl, "https://a");
+    assert.equal(result.computers[1]!.diskSizeMb, 15360);
+    assert.equal(result.computers[1]!.templateId, "browser-agent");
     assert.equal(result.computers[1]!.stoppedAt, "2026-04-16T01:00:00Z");
+  });
+
+  it("listTemplates() maps sandbox template metadata", async () => {
+    const { fetch, calls } = makeFetchMock(() => ({
+      status: 200,
+      body: [
+        {
+          id: "coding-agent",
+          display_name: "Coding Agent",
+          description: "Ready-to-code sandbox",
+          default_vcpus: 1,
+          default_ram_mb: 1024,
+          default_disk_size_mb: 15360,
+          version: "latest",
+          experimental: false,
+        },
+      ],
+    }));
+    const client = new ComputersClient(makeConfig(fetch));
+
+    const templates = await client.listTemplates();
+
+    assert.equal(calls[0]!.method, "GET");
+    assert.equal(calls[0]!.url, "https://api.example.test/v1/computers/templates");
+    assert.equal(templates[0]!.id, "coding-agent");
+    assert.equal(templates[0]!.displayName, "Coding Agent");
+    assert.equal(templates[0]!.defaultDiskSizeMb, 15360);
   });
 
   it("get() resolves name to ID via /v1/computers/{name}", async () => {
@@ -154,7 +212,9 @@ describe("ComputersClient", () => {
         status: "running",
         vcpus: 1,
         ram_mb: 1024,
+        disk_size_mb: 7168,
         image: "ubuntu-desktop-24.04",
+        template_id: "scratch",
         created_at: "2026-04-16T00:00:00Z",
       },
     }));
@@ -193,7 +253,9 @@ describe("ComputersClient", () => {
           status: "stopping",
           vcpus: 1,
           ram_mb: 1024,
+          disk_size_mb: 7168,
           image: "ubuntu-desktop-24.04",
+          template_id: "scratch",
           created_at: "2026-04-16T00:00:00Z",
         },
       };
@@ -221,7 +283,9 @@ describe("ComputersClient", () => {
     await assert.rejects(
       () => client.get("cmp_missing"),
       (err: unknown) => {
-        assert.ok(err instanceof CelestoApiError);
+        if (!(err instanceof CelestoApiError)) {
+          return false;
+        }
         assert.ok(err instanceof CelestoError, "CelestoApiError should extend CelestoError");
         assert.equal(err.status, 404);
         assert.equal(err.message, "Computer not found");
@@ -239,7 +303,9 @@ describe("ComputersClient", () => {
     await assert.rejects(
       () => client.list(),
       (err: unknown) => {
-        assert.ok(err instanceof CelestoNetworkError);
+        if (!(err instanceof CelestoNetworkError)) {
+          return false;
+        }
         assert.ok(err instanceof CelestoError, "CelestoNetworkError should extend CelestoError");
         assert.match(err.message, /fetch failed/);
         return true;
@@ -256,7 +322,9 @@ describe("ComputersClient", () => {
         status: "running",
         vcpus: 1,
         ram_mb: 1024,
+        disk_size_mb: 7168,
         image: "ubuntu-desktop-24.04",
+        template_id: "scratch",
         created_at: "2026-04-16T00:00:00Z",
       },
     }));
@@ -278,7 +346,9 @@ describe("ComputersClient", () => {
         status: "running",
         vcpus: 1,
         ram_mb: 1024,
+        disk_size_mb: 7168,
         image: "ubuntu-desktop-24.04",
+        template_id: "scratch",
         created_at: "2026-04-16T00:00:00Z",
       },
     }));

--- a/src/celesto/computer.py
+++ b/src/celesto/computer.py
@@ -188,7 +188,7 @@ def list_templates(
     as_json: JsonOption = False,
     api_key: ApiKeyOption = None,
 ):
-    """List available sandbox templates."""
+    """List ready-made computer setups."""
     with _get_client(api_key) as client:
         templates = client.computers.list_templates()
 

--- a/src/celesto/computer.py
+++ b/src/celesto/computer.py
@@ -41,6 +41,8 @@ def _status_color(status: str) -> str:
         "stopping": "yellow",
         "stopped": "dim",
         "starting": "yellow",
+        "restoring": "yellow",
+        "restorable": "cyan",
         "deleting": "yellow",
         "deleted": "dim",
         "error": "red",
@@ -62,9 +64,31 @@ def _print_json(data: object) -> None:
 @app.command("create")
 def create_computer(
     cpus: Annotated[
-        int, typer.Option("--cpus", "-c", help="Number of virtual CPUs")
-    ] = 1,
-    memory: Annotated[int, typer.Option("--memory", "-m", help="Memory in MB")] = 1024,
+        Optional[int], typer.Option("--cpus", "-c", help="Number of virtual CPUs")
+    ] = None,
+    memory: Annotated[
+        Optional[int], typer.Option("--memory", "-m", help="Memory in MB")
+    ] = None,
+    disk_size_mb: Annotated[
+        Optional[int],
+        typer.Option("--disk-size-mb", "--disk", help="Disk size in MB"),
+    ] = None,
+    template_id: Annotated[
+        Optional[str],
+        typer.Option(
+            "--template",
+            "--template-id",
+            help="Sandbox template id, such as scratch, coding-agent, or browser-agent",
+        ),
+    ] = None,
+    template_version: Annotated[
+        Optional[str],
+        typer.Option("--template-version", help="Immutable template version"),
+    ] = None,
+    image: Annotated[
+        Optional[str],
+        typer.Option("--image", help="Legacy image selector"),
+    ] = None,
     as_json: JsonOption = False,
     api_key: ApiKeyOption = None,
 ):
@@ -72,7 +96,14 @@ def create_computer(
     with _get_client(api_key) as client:
         if not as_json:
             console.print("Creating computer...", style="dim")
-        result = client.computers.create(cpus=cpus, memory=memory)
+        result = client.computers.create(
+            cpus=cpus,
+            memory=memory,
+            disk_size_mb=disk_size_mb,
+            template_id=template_id,
+            template_version=template_version,
+            image=image,
+        )
 
     if as_json:
         _print_json(result)
@@ -86,8 +117,10 @@ def create_computer(
     console.print(f"  Name:   [bold]{cname}[/bold]")
     console.print(f"  ID:     [dim]{cid}[/dim]")
     console.print(f"  Status: [{color}]{status}[/{color}]")
-    console.print(f"  CPUs:   {cpus}")
-    console.print(f"  Memory: {_format_memory(memory)}")
+    console.print(f"  CPUs:   {result.get('vcpus')}")
+    console.print(f"  Memory: {_format_memory(result.get('ram_mb', 0))}")
+    console.print(f"  Disk:   {_format_memory(result.get('disk_size_mb', 0))}")
+    console.print(f"  Template: {result.get('template_id', 'scratch')}")
     console.print()
     console.print(f"[dim]Connect with:[/dim] celesto computer ssh {cname}")
 
@@ -118,6 +151,8 @@ def list_computers(
     table.add_column("Status")
     table.add_column("CPUs", justify="right")
     table.add_column("Memory", justify="right")
+    table.add_column("Disk", justify="right")
+    table.add_column("Template")
     table.add_column("Created")
 
     for c in computers:
@@ -128,7 +163,45 @@ def list_computers(
             f"[{color}]{c['status']}[/{color}]",
             str(c["vcpus"]),
             _format_memory(c["ram_mb"]),
+            _format_memory(c.get("disk_size_mb", 0)),
+            c.get("template_id", "scratch"),
             c.get("created_at", "")[:19],
+        )
+
+    console.print(table)
+
+
+@app.command("templates")
+def list_templates(
+    as_json: JsonOption = False,
+    api_key: ApiKeyOption = None,
+):
+    """List available sandbox templates."""
+    with _get_client(api_key) as client:
+        templates = client.computers.list_templates()
+
+    if as_json:
+        _print_json(templates)
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("ID", style="bold")
+    table.add_column("Name")
+    table.add_column("CPUs", justify="right")
+    table.add_column("Memory", justify="right")
+    table.add_column("Disk", justify="right")
+    table.add_column("Version")
+    table.add_column("Experimental")
+
+    for template in templates:
+        table.add_row(
+            template["id"],
+            template["display_name"],
+            str(template["default_vcpus"]),
+            _format_memory(template["default_ram_mb"]),
+            _format_memory(template["default_disk_size_mb"]),
+            template.get("version") or "",
+            "yes" if template.get("experimental") else "",
         )
 
     console.print(table)
@@ -155,7 +228,7 @@ def run_command(
         except CelestoServerError as e:
             if "stopped" in str(e).lower() or "409" in str(e):
                 if not as_json:
-                    console.print(f"[yellow]Computer is stopped. Resuming...[/yellow]")
+                    console.print("[yellow]Computer is stopped. Resuming...[/yellow]")
                 client.computers.start(computer_id)
                 # Wait for it to be running
                 for _ in range(30):
@@ -206,7 +279,7 @@ def ssh_to_computer(
         info = client.computers.get(computer_id)
         resolved_id = info.get("id", computer_id)
         if info.get("status") == "stopped":
-            console.print(f"[yellow]Computer is stopped. Resuming...[/yellow]")
+            console.print("[yellow]Computer is stopped. Resuming...[/yellow]")
             client.computers.start(resolved_id)
             for _ in range(30):
                 info = client.computers.get(resolved_id)
@@ -257,7 +330,9 @@ def ssh_to_computer(
                     os.write(sys.stdout.fileno(), msg)
         except websockets.exceptions.ConnectionClosed as e:
             if e.rcvd and e.rcvd.code != 1000:
-                console.print(f"\n[red]Connection closed: code={e.rcvd.code} reason={e.rcvd.reason}[/red]")
+                console.print(
+                    f"\n[red]Connection closed: code={e.rcvd.code} reason={e.rcvd.reason}[/red]"
+                )
         except OSError:
             pass
         finally:

--- a/src/celesto/computer.py
+++ b/src/celesto/computer.py
@@ -56,6 +56,18 @@ def _format_memory(mb: int) -> str:
     return f"{mb} MB"
 
 
+def _format_optional_memory(value: object) -> str:
+    if isinstance(value, int):
+        return _format_memory(value)
+    return "N/A"
+
+
+def _format_optional_text(value: object) -> str:
+    if isinstance(value, str) and value:
+        return value
+    return "N/A"
+
+
 def _print_json(data: object) -> None:
     """Print JSON to stdout (no Rich formatting)."""
     sys.stdout.write(json.dumps(data, indent=2, default=str) + "\n")
@@ -118,9 +130,9 @@ def create_computer(
     console.print(f"  ID:     [dim]{cid}[/dim]")
     console.print(f"  Status: [{color}]{status}[/{color}]")
     console.print(f"  CPUs:   {result.get('vcpus')}")
-    console.print(f"  Memory: {_format_memory(result.get('ram_mb', 0))}")
-    console.print(f"  Disk:   {_format_memory(result.get('disk_size_mb', 0))}")
-    console.print(f"  Template: {result.get('template_id', 'scratch')}")
+    console.print(f"  Memory: {_format_optional_memory(result.get('ram_mb'))}")
+    console.print(f"  Disk:   {_format_optional_memory(result.get('disk_size_mb'))}")
+    console.print(f"  Template: {_format_optional_text(result.get('template_id'))}")
     console.print()
     console.print(f"[dim]Connect with:[/dim] celesto computer ssh {cname}")
 
@@ -163,8 +175,8 @@ def list_computers(
             f"[{color}]{c['status']}[/{color}]",
             str(c["vcpus"]),
             _format_memory(c["ram_mb"]),
-            _format_memory(c.get("disk_size_mb", 0)),
-            c.get("template_id", "scratch"),
+            _format_optional_memory(c.get("disk_size_mb")),
+            _format_optional_text(c.get("template_id")),
             c.get("created_at", "")[:19],
         )
 

--- a/src/celesto/integrations/openai_agents/hosted.py
+++ b/src/celesto/integrations/openai_agents/hosted.py
@@ -86,7 +86,6 @@ class CelestoSandboxSession(CommandBackedSession):
         deadline = time.monotonic() + self.state.start_timeout_seconds
         delay = max(0.25, self.state.start_poll_interval_seconds)
         last_status: str | None = None
-        last_error: str | None = None
 
         while time.monotonic() < deadline:
             try:
@@ -94,28 +93,25 @@ class CelestoSandboxSession(CommandBackedSession):
                     self._client.computers.get,
                     self.state.computer_id,
                 )
-            except Exception as exc:
-                last_error = f"{type(exc).__name__}: {exc}"
+            except Exception:
                 await asyncio.sleep(delay)
                 delay = min(delay * 1.5, 5)
                 continue
 
             last_status = str(info.get("status"))
-            last_error = info.get("last_error")
             if last_status == "running":
                 return
             if last_status == "error":
                 raise RuntimeError(
-                    f"Celesto computer {self.state.computer_id} failed to start"
-                    f": {last_error or 'status=error'}"
+                    f"Computer {self.state.computer_id} could not start. "
+                    f"Delete it with client.computers.delete('{self.state.computer_id}') and create a new one."
                 )
 
             await asyncio.sleep(delay)
 
-        detail = last_error or f"last status was {last_status or 'unknown'}"
         raise RuntimeError(
-            f"Celesto computer {self.state.computer_id} did not reach running "
-            f"within {self.state.start_timeout_seconds:g}s ({detail})."
+            f"Computer {self.state.computer_id} is not ready yet. "
+            f"Check it with client.computers.get('{self.state.computer_id}') and try again."
         )
 
     async def _ensure_backend_started(self) -> None:

--- a/src/celesto/integrations/openai_agents/hosted.py
+++ b/src/celesto/integrations/openai_agents/hosted.py
@@ -31,9 +31,12 @@ class CelestoSandboxClientOptions(BaseSandboxClientOptions):
 
     type: Literal["celesto"] = "celesto"
     computer_id: str | None = None
-    cpus: int = 1
-    memory: int = 1024
-    image: str = "ubuntu-desktop-24.04"
+    cpus: int | None = None
+    memory: int | None = None
+    disk_size_mb: int | None = None
+    image: str | None = None
+    template_id: str | None = "coding-agent"
+    template_version: str | None = None
     delete_on_close: bool | None = None
 
 
@@ -42,9 +45,12 @@ class CelestoSandboxSessionState(SandboxSessionState):
 
     type: Literal["celesto"] = "celesto"
     computer_id: str | None = None
-    cpus: int = 1
-    memory: int = 1024
-    image: str = "ubuntu-desktop-24.04"
+    cpus: int | None = None
+    memory: int | None = None
+    disk_size_mb: int | None = None
+    image: str | None = None
+    template_id: str | None = "coding-agent"
+    template_version: str | None = None
     delete_on_close: bool = True
 
 
@@ -74,14 +80,21 @@ class CelestoSandboxSession(CommandBackedSession):
                 self._client.computers.create,
                 cpus=self.state.cpus,
                 memory=self.state.memory,
+                disk_size_mb=self.state.disk_size_mb,
                 image=self.state.image,
+                template_id=self.state.template_id,
+                template_version=self.state.template_version,
             )
             self.state.computer_id = created["id"]
             return
 
-        info = await asyncio.to_thread(self._client.computers.get, self.state.computer_id)
+        info = await asyncio.to_thread(
+            self._client.computers.get, self.state.computer_id
+        )
         if info.get("status") == "stopped":
-            await asyncio.to_thread(self._client.computers.start, self.state.computer_id)
+            await asyncio.to_thread(
+                self._client.computers.start, self.state.computer_id
+            )
 
     async def _shutdown_backend(self) -> None:
         if self.state.computer_id is None:
@@ -90,7 +103,9 @@ class CelestoSandboxSession(CommandBackedSession):
             await asyncio.to_thread(self._client.computers.stop, self.state.computer_id)
         self._running = False
 
-    async def _run_guest(self, command: str, *, timeout: float | None = None) -> dict[str, Any]:
+    async def _run_guest(
+        self, command: str, *, timeout: float | None = None
+    ) -> dict[str, Any]:
         if self.state.computer_id is None:
             raise RuntimeError(
                 "No Celesto computer is ready yet. Start the session with "
@@ -109,7 +124,9 @@ class CelestoSandboxSession(CommandBackedSession):
             return
         if self.state.delete_on_close:
             with suppress(Exception):
-                await asyncio.to_thread(self._client.computers.delete, self.state.computer_id)
+                await asyncio.to_thread(
+                    self._client.computers.delete, self.state.computer_id
+                )
         self._running = False
 
 
@@ -140,7 +157,9 @@ class CelestoSandboxClient(BaseSandboxClient[CelestoSandboxClientOptions | None]
         session_id = uuid.uuid4()
         created_by_client = resolved.computer_id is None
         delete_on_close = (
-            created_by_client if resolved.delete_on_close is None else resolved.delete_on_close
+            created_by_client
+            if resolved.delete_on_close is None
+            else resolved.delete_on_close
         )
         state = CelestoSandboxSessionState(
             session_id=session_id,
@@ -149,7 +168,10 @@ class CelestoSandboxClient(BaseSandboxClient[CelestoSandboxClientOptions | None]
             computer_id=resolved.computer_id,
             cpus=resolved.cpus,
             memory=resolved.memory,
+            disk_size_mb=resolved.disk_size_mb,
             image=resolved.image,
+            template_id=resolved.template_id,
+            template_version=resolved.template_version,
             delete_on_close=delete_on_close,
         )
         inner = CelestoSandboxSession.from_state(state, client=self._client)
@@ -174,7 +196,9 @@ class CelestoSandboxClient(BaseSandboxClient[CelestoSandboxClientOptions | None]
         inner._set_start_state_preserved(True)
         return self._wrap_session(inner)
 
-    def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
+    def deserialize_session_state(
+        self, payload: dict[str, object]
+    ) -> SandboxSessionState:
         return CelestoSandboxSessionState.model_validate(payload)
 
 

--- a/src/celesto/integrations/openai_agents/hosted.py
+++ b/src/celesto/integrations/openai_agents/hosted.py
@@ -7,6 +7,7 @@ Use this module when you want Celesto to create the computer for an OpenAI
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
 from contextlib import suppress
 from typing import Any, Literal
@@ -37,6 +38,8 @@ class CelestoSandboxClientOptions(BaseSandboxClientOptions):
     image: str | None = None
     template_id: str | None = "coding-agent"
     template_version: str | None = None
+    start_timeout_seconds: float = 120
+    start_poll_interval_seconds: float = 2
     delete_on_close: bool | None = None
 
 
@@ -51,6 +54,8 @@ class CelestoSandboxSessionState(SandboxSessionState):
     image: str | None = None
     template_id: str | None = "coding-agent"
     template_version: str | None = None
+    start_timeout_seconds: float = 120
+    start_poll_interval_seconds: float = 2
     delete_on_close: bool = True
 
 
@@ -74,6 +79,45 @@ class CelestoSandboxSession(CommandBackedSession):
     ) -> "CelestoSandboxSession":
         return cls(state=state, client=client)
 
+    async def _wait_for_running(self) -> None:
+        if self.state.computer_id is None:
+            return
+
+        deadline = time.monotonic() + self.state.start_timeout_seconds
+        delay = max(0.25, self.state.start_poll_interval_seconds)
+        last_status: str | None = None
+        last_error: str | None = None
+
+        while time.monotonic() < deadline:
+            try:
+                info = await asyncio.to_thread(
+                    self._client.computers.get,
+                    self.state.computer_id,
+                )
+            except Exception as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+                await asyncio.sleep(delay)
+                delay = min(delay * 1.5, 5)
+                continue
+
+            last_status = str(info.get("status"))
+            last_error = info.get("last_error")
+            if last_status == "running":
+                return
+            if last_status == "error":
+                raise RuntimeError(
+                    f"Celesto computer {self.state.computer_id} failed to start"
+                    f": {last_error or 'status=error'}"
+                )
+
+            await asyncio.sleep(delay)
+
+        detail = last_error or f"last status was {last_status or 'unknown'}"
+        raise RuntimeError(
+            f"Celesto computer {self.state.computer_id} did not reach running "
+            f"within {self.state.start_timeout_seconds:g}s ({detail})."
+        )
+
     async def _ensure_backend_started(self) -> None:
         if self.state.computer_id is None:
             created = await asyncio.to_thread(
@@ -86,6 +130,8 @@ class CelestoSandboxSession(CommandBackedSession):
                 template_version=self.state.template_version,
             )
             self.state.computer_id = created["id"]
+            if created.get("status") != "running":
+                await self._wait_for_running()
             return
 
         info = await asyncio.to_thread(
@@ -95,6 +141,9 @@ class CelestoSandboxSession(CommandBackedSession):
             await asyncio.to_thread(
                 self._client.computers.start, self.state.computer_id
             )
+            await self._wait_for_running()
+        elif info.get("status") != "running":
+            await self._wait_for_running()
 
     async def _shutdown_backend(self) -> None:
         if self.state.computer_id is None:
@@ -172,6 +221,8 @@ class CelestoSandboxClient(BaseSandboxClient[CelestoSandboxClientOptions | None]
             image=resolved.image,
             template_id=resolved.template_id,
             template_version=resolved.template_version,
+            start_timeout_seconds=resolved.start_timeout_seconds,
+            start_poll_interval_seconds=resolved.start_poll_interval_seconds,
             delete_on_close=delete_on_close,
         )
         inner = CelestoSandboxSession.from_state(state, client=self._client)

--- a/src/celesto/sdk/__init__.py
+++ b/src/celesto/sdk/__init__.py
@@ -23,6 +23,7 @@ from .types import (
     DeploymentResponse,
     DriveFile,
     DriveFilesResponse,
+    SandboxTemplateInfo,
 )
 
 __all__ = [
@@ -49,6 +50,7 @@ __all__ = [
     "ComputerStatus",
     "ComputerConnectionInfo",
     "ComputerInfo",
+    "SandboxTemplateInfo",
     "ComputerListResponse",
     "ComputerExecResponse",
 ]

--- a/src/celesto/sdk/client.py
+++ b/src/celesto/sdk/client.py
@@ -795,7 +795,7 @@ class Computers(_BaseClient):
 
     Example:
         >>> with Celesto() as client:
-        ...     computer = client.computers.create(cpus=2, memory=2048)
+        ...     computer = client.computers.create(template_id="coding-agent")
         ...     result = client.computers.exec(computer["id"], "uname -a")
         ...     print(result["stdout"])
         ...     client.computers.delete(computer["id"])
@@ -804,25 +804,70 @@ class Computers(_BaseClient):
     def create(
         self,
         *,
-        cpus: int = 1,
-        memory: int = 1024,
-        image: str = "ubuntu-desktop-24.04",
+        cpus: int | None = None,
+        memory: int | None = None,
+        vcpus: int | None = None,
+        ram_mb: int | None = None,
+        disk_size_mb: int | None = None,
+        image: str | None = None,
+        template_id: str | None = None,
+        template_version: str | None = None,
     ) -> dict[str, Any]:
         """Create a new sandboxed computer.
 
+        Resource fields are optional. If omitted, the backend applies the
+        selected template's defaults.
+
         Args:
-            cpus: Number of virtual CPUs (1-16).
-            memory: Memory in MB (512-32768).
-            image: OS image name.
+            cpus: Number of virtual CPUs (1-16). Alias for vcpus.
+            memory: Memory in MB (512-32768). Alias for ram_mb.
+            vcpus: Number of virtual CPUs (1-16).
+            ram_mb: Memory in MB (512-32768).
+            disk_size_mb: Disk size in MB (512-51200).
+            image: Legacy OS image selector.
+            template_id: Sandbox template id, such as "scratch" or
+                "coding-agent".
+            template_version: Optional immutable template version.
 
         Returns:
-            Computer info dict with id, status, cpus, memory, etc.
+            Computer info dict with id, status, resources, template, etc.
         """
+        if cpus is not None and vcpus is not None and cpus != vcpus:
+            raise CelestoValidationError("Pass either cpus or vcpus, not both.")
+        if memory is not None and ram_mb is not None and memory != ram_mb:
+            raise CelestoValidationError("Pass either memory or ram_mb, not both.")
+
+        resolved_vcpus = vcpus if vcpus is not None else cpus
+        resolved_ram_mb = ram_mb if ram_mb is not None else memory
+
+        payload: dict[str, Any] = {}
+        if resolved_vcpus is not None:
+            payload["vcpus"] = resolved_vcpus
+        if resolved_ram_mb is not None:
+            payload["ram_mb"] = resolved_ram_mb
+        if disk_size_mb is not None:
+            payload["disk_size_mb"] = disk_size_mb
+        if image is not None:
+            payload["image"] = image
+        if template_id is not None:
+            payload["template_id"] = template_id
+        if template_version is not None:
+            payload["template_version"] = template_version
+
         return self._request(
             "POST",
             "/computers",
-            json_body={"vcpus": cpus, "ram_mb": memory, "image": image},
+            json_body=payload,
         )
+
+    def list_templates(self) -> list[dict[str, Any]]:
+        """List available sandbox templates.
+
+        Returns:
+            List of template dicts with id, display_name, description, default
+            resources, version, and experimental fields.
+        """
+        return self._request("GET", "/computers/templates")
 
     def list(self) -> dict[str, Any]:
         """List all computers in the current organization.

--- a/src/celesto/sdk/client.py
+++ b/src/celesto/sdk/client.py
@@ -833,9 +833,13 @@ class Computers(_BaseClient):
             Computer info dict with id, status, resources, template, etc.
         """
         if cpus is not None and vcpus is not None and cpus != vcpus:
-            raise CelestoValidationError("Pass either cpus or vcpus, not both.")
+            raise CelestoValidationError(
+                "cpus and vcpus must have the same value when both are provided."
+            )
         if memory is not None and ram_mb is not None and memory != ram_mb:
-            raise CelestoValidationError("Pass either memory or ram_mb, not both.")
+            raise CelestoValidationError(
+                "memory and ram_mb must have the same value when both are provided."
+            )
 
         resolved_vcpus = vcpus if vcpus is not None else cpus
         resolved_ram_mb = ram_mb if ram_mb is not None else memory

--- a/src/celesto/sdk/types.py
+++ b/src/celesto/sdk/types.py
@@ -108,6 +108,8 @@ ComputerStatus = Literal[
     "stopping",
     "stopped",
     "starting",
+    "restoring",
+    "restorable",
     "deleting",
     "deleted",
     "error",
@@ -129,11 +131,27 @@ class ComputerInfo(TypedDict):
     status: ComputerStatus
     vcpus: int
     ram_mb: int
+    disk_size_mb: int
     image: str
-    connection: NotRequired[ComputerConnectionInfo]
-    last_error: NotRequired[str]
+    template_id: str
+    template_version: NotRequired[str | None]
+    connection: NotRequired[ComputerConnectionInfo | None]
+    last_error: NotRequired[str | None]
     created_at: str
-    stopped_at: NotRequired[str]
+    stopped_at: NotRequired[str | None]
+
+
+class SandboxTemplateInfo(TypedDict):
+    """A sandbox template available for computer creation."""
+
+    id: str
+    display_name: str
+    description: str
+    default_vcpus: int
+    default_ram_mb: int
+    default_disk_size_mb: int
+    version: NotRequired[str | None]
+    experimental: bool
 
 
 class ComputerListResponse(TypedDict):
@@ -171,6 +189,7 @@ __all__ = [
     "ComputerStatus",
     "ComputerConnectionInfo",
     "ComputerInfo",
+    "SandboxTemplateInfo",
     "ComputerListResponse",
     "ComputerExecResponse",
 ]

--- a/tests/test_celestoignore_spec.py
+++ b/tests/test_celestoignore_spec.py
@@ -7,8 +7,6 @@ These tests verify that .celestoignore follows the gitignore specification:
 4. Patterns with # in the middle should match literally
 """
 
-import tarfile
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,4 +1,26 @@
+import httpx
+import pytest
+
 from celesto.sdk import Celesto
+from celesto.sdk.exceptions import CelestoValidationError
+
+
+class DummySession:
+    def __init__(self, *, status_code: int = 200, payload=None):
+        self.status_code = status_code
+        self.payload = payload if payload is not None else {}
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        return httpx.Response(
+            self.status_code,
+            json=self.payload,
+            request=httpx.Request(method, url),
+        )
+
+    def close(self):
+        pass
 
 
 def test_sdk_exposes_service_clients():
@@ -6,3 +28,81 @@ def test_sdk_exposes_service_clients():
     assert hasattr(client, "deployment")
     assert hasattr(client, "gatekeeper")
     assert hasattr(client, "computers")
+
+
+def test_computers_create_sends_only_explicit_overrides():
+    session = DummySession(
+        status_code=201,
+        payload={
+            "id": "cmp_1",
+            "name": "curie",
+            "status": "creating",
+            "vcpus": 1,
+            "ram_mb": 1024,
+            "disk_size_mb": 15360,
+            "image": "ubuntu-desktop-24.04",
+            "template_id": "coding-agent",
+            "template_version": "latest",
+            "created_at": "2026-06-07T00:00:00Z",
+        },
+    )
+    client = Celesto("test-key", base_url="https://api.example.test/v1")
+    client.session = session
+
+    result = client.computers.create(
+        template_id="coding-agent",
+        disk_size_mb=15360,
+    )
+
+    assert result["template_id"] == "coding-agent"
+    assert session.calls[0]["method"] == "POST"
+    assert session.calls[0]["url"] == "https://api.example.test/v1/computers"
+    assert session.calls[0]["json"] == {
+        "disk_size_mb": 15360,
+        "template_id": "coding-agent",
+    }
+
+
+def test_computers_create_with_no_args_uses_backend_defaults():
+    session = DummySession(status_code=201, payload={})
+    client = Celesto("test-key", base_url="https://api.example.test/v1")
+    client.session = session
+
+    client.computers.create()
+
+    assert session.calls[0]["json"] == {}
+
+
+def test_computers_create_rejects_conflicting_aliases():
+    client = Celesto("test-key", base_url="https://api.example.test/v1")
+
+    with pytest.raises(CelestoValidationError):
+        client.computers.create(cpus=1, vcpus=2)
+
+    with pytest.raises(CelestoValidationError):
+        client.computers.create(memory=1024, ram_mb=2048)
+
+
+def test_computers_list_templates_hits_backend_endpoint():
+    session = DummySession(
+        payload=[
+            {
+                "id": "scratch",
+                "display_name": "Scratch",
+                "description": "Minimal VM",
+                "default_vcpus": 1,
+                "default_ram_mb": 512,
+                "default_disk_size_mb": 7168,
+                "version": "latest",
+                "experimental": False,
+            }
+        ]
+    )
+    client = Celesto("test-key", base_url="https://api.example.test/v1")
+    client.session = session
+
+    templates = client.computers.list_templates()
+
+    assert templates[0]["id"] == "scratch"
+    assert session.calls[0]["method"] == "GET"
+    assert session.calls[0]["url"] == "https://api.example.test/v1/computers/templates"


### PR DESCRIPTION
## Summary
- Add template-aware computer creation to the Python and Node SDKs, including `template_id` / `templateId`, `template_version`, and `disk_size_mb` / `diskSizeMb` support.
- Stop hardcoding create-time defaults so the backend can apply template defaults, and add template listing helpers in both clients.
- Update the Python CLI, OpenAI Agents hosted integration, docs, and SDK tests to reflect the new computer and template contract.

## Testing
- `uv run ruff check .`
- `uv run pytest`
- `npm run lint`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added template-based computer creation with template selection and optional version pinning
  * Added ability to list available sandbox templates and their default resources
  * Added disk size configuration support for computers
  * New computer status states: "restoring" and "restorable"

* **Documentation**
  * Updated examples across README files to use template-based creation workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->