### PR TITLE
Add Celesto CLI auth commands with secure key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Requires Python 3.10+.
 
 Get your API key from [celesto.ai](https://celesto.ai) under **Settings > Security**.
 
+For CLI commands, save it once:
+
+```bash
+celesto auth login
+```
+
+The CLI stores the key in your operating system's secure credential store and
+uses it for future commands.
+
 ```bash
 export CELESTO_API_KEY="your-api-key"
 ```
@@ -188,6 +197,9 @@ for vm in result["computers"]:
 
 | Command | Description |
 |---|---|
+| `celesto auth login` | Save your API key |
+| `celesto auth status` | Check whether an API key is saved |
+| `celesto auth logout` | Remove your saved API key |
 | `celesto computer create [--template ID] [--cpus N] [--memory MB] [--disk-size-mb MB]` | Create a computer |
 | `celesto computer templates` | List computer templates |
 | `celesto computer list` | List all computers |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "a2a-sdk>=0.3.10",
     "fastmcp>=2.7.1",
     "httpx>=0.27.0",
+    "keyring>=25.7.0",
     "pathspec>=0.11.0",
     "python-dotenv>=1.0.0",
     "rich>=14.0.0",

--- a/src/celesto/auth.py
+++ b/src/celesto/auth.py
@@ -1,0 +1,143 @@
+"""CLI commands for signing in to Celesto."""
+
+from __future__ import annotations
+
+import os
+
+import keyring
+import typer
+from keyring.errors import KeyringError
+from rich.console import Console
+from typing_extensions import Annotated
+
+from .sdk.client import Celesto
+
+DEFAULT_BASE_URL = "https://api.celesto.ai/v1"
+KEYRING_SERVICE = "celesto"
+
+app = typer.Typer(help="Sign in and manage saved credentials.")
+console = Console()
+
+BaseUrlOption = Annotated[
+    str,
+    typer.Option(
+        "--base-url",
+        help="Celesto API URL",
+        envvar="CELESTO_BASE_URL",
+    ),
+]
+
+
+def _credential_account(base_url: str) -> str:
+    return f"api_key:{base_url.rstrip('/')}"
+
+
+def _resolve_base_url(base_url: str | None = None) -> str:
+    return (base_url or os.environ.get("CELESTO_BASE_URL") or DEFAULT_BASE_URL).rstrip(
+        "/"
+    )
+
+
+def save_api_key(api_key: str, base_url: str | None = None) -> None:
+    """Save an API key in the operating system's secure credential store."""
+    resolved_base_url = _resolve_base_url(base_url)
+    keyring.set_password(
+        KEYRING_SERVICE,
+        _credential_account(resolved_base_url),
+        api_key,
+    )
+
+
+def load_api_key(base_url: str | None = None) -> str | None:
+    """Load a saved API key from the operating system's secure credential store."""
+    resolved_base_url = _resolve_base_url(base_url)
+    try:
+        return keyring.get_password(
+            KEYRING_SERVICE,
+            _credential_account(resolved_base_url),
+        )
+    except KeyringError:
+        return None
+
+
+def delete_api_key(base_url: str | None = None) -> None:
+    """Delete a saved API key from the operating system's secure credential store."""
+    resolved_base_url = _resolve_base_url(base_url)
+    try:
+        keyring.delete_password(
+            KEYRING_SERVICE,
+            _credential_account(resolved_base_url),
+        )
+    except KeyringError:
+        return
+
+
+def validate_api_key(api_key: str, base_url: str | None = None) -> None:
+    """Check that the API key can call Celesto."""
+    client = Celesto(api_key=api_key, base_url=_resolve_base_url(base_url))
+    try:
+        client.computers.list_templates()
+    finally:
+        client.close()
+
+
+@app.command("login")
+def login(
+    api_key: Annotated[
+        str | None,
+        typer.Option(
+            "--api-key",
+            "-k",
+            help="Celesto API key",
+            prompt="Paste your Celesto API key",
+            hide_input=True,
+        ),
+    ] = None,
+    base_url: BaseUrlOption = DEFAULT_BASE_URL,
+):
+    """Save your Celesto API key for future CLI commands."""
+    if not api_key:
+        console.print("No API key was provided. Run celesto auth login.")
+        raise typer.Exit(1)
+
+    resolved_base_url = _resolve_base_url(base_url)
+    try:
+        validate_api_key(api_key, resolved_base_url)
+    except Exception as exc:
+        console.print("That API key did not work. Check it and run celesto auth login again.")
+        raise typer.Exit(1) from exc
+
+    try:
+        save_api_key(api_key, resolved_base_url)
+    except KeyringError as exc:
+        console.print(
+            "Your API key could not be saved securely. Set CELESTO_API_KEY and try your command again."
+        )
+        raise typer.Exit(1) from exc
+
+    console.print(
+        "Saved your Celesto API key. You can now run commands like celesto computer list."
+    )
+
+
+@app.command("status")
+def status(base_url: BaseUrlOption = DEFAULT_BASE_URL):
+    """Show whether a Celesto API key is saved."""
+    resolved_base_url = _resolve_base_url(base_url)
+    if load_api_key(resolved_base_url):
+        console.print(
+            f"A Celesto API key is saved for {resolved_base_url}. Run celesto auth logout to remove it."
+        )
+        return
+
+    console.print("No saved API key was found. Run celesto auth login.")
+
+
+@app.command("logout")
+def logout(base_url: BaseUrlOption = DEFAULT_BASE_URL):
+    """Remove your saved Celesto API key."""
+    resolved_base_url = _resolve_base_url(base_url)
+    delete_api_key(resolved_base_url)
+    console.print(
+        "Removed your saved Celesto API key. Run celesto auth login to sign in again."
+    )

--- a/src/celesto/deployment.py
+++ b/src/celesto/deployment.py
@@ -10,6 +10,7 @@ from dotenv.main import DotEnv
 from rich.console import Console
 from typing_extensions import Annotated
 
+from .auth import load_api_key
 from .sdk.client import Celesto
 
 console = Console()
@@ -36,15 +37,10 @@ def _get_api_key(
     final_api_key = api_key or os.environ.get(secret_name or "CELESTO_API_KEY")
     if not final_api_key and not ignore_env_file:
         final_api_key = _get_secrets_from_env_file(secret_name=secret_name)
+    if not final_api_key and (secret_name or "CELESTO_API_KEY") == "CELESTO_API_KEY":
+        final_api_key = load_api_key()
     if not final_api_key:
-        console.print("❌ [bold red]Error:[/bold red] API key not found.")
-        console.print(
-            "Please provide it via [bold]--api-key[/bold] or set [bold]CELESTO_API_KEY[/bold] environment variable."
-        )
-        console.print("\n[bold cyan]To get your API key:[/bold cyan]")
-        console.print("1. Log in to https://celesto.ai")
-        console.print("2. Navigate to Settings → Security")
-        console.print("3. Copy your API key")
+        console.print("No Celesto API key was found. Run celesto auth login.")
         raise typer.Exit(1)
     return final_api_key
 

--- a/src/celesto/deployment.py
+++ b/src/celesto/deployment.py
@@ -24,7 +24,7 @@ def _get_secrets_from_env_file(
     if not secret_name:
         secret_name = "CELESTO_API_KEY"
     dotenv_path = Path(env_file)
-    dot_env = DotEnv(dotenv_path, verbose=True, encoding="utf-8")
+    dot_env = DotEnv(dotenv_path, verbose=False, encoding="utf-8")
     return dot_env.get(secret_name)
 
 

--- a/src/celesto/main.py
+++ b/src/celesto/main.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import typer
 from rich import print
 
-from . import computer
+from . import auth, computer
 
 app = typer.Typer(
     help="Infrastructure for sandboxes and computer-use agents.",
     no_args_is_help=True,
 )
+app.add_typer(auth.app, name="auth")
 app.add_typer(computer.app, name="computer")
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from celesto import auth
+from celesto.deployment import _get_api_key
+
+
+def test_auth_helpers_use_base_url_scoped_keyring(monkeypatch):
+    calls = []
+
+    def fake_set_password(service: str, account: str, password: str) -> None:
+        calls.append(("set", service, account, password))
+
+    def fake_get_password(service: str, account: str) -> str:
+        calls.append(("get", service, account))
+        return "stored-key"
+
+    def fake_delete_password(service: str, account: str) -> None:
+        calls.append(("delete", service, account))
+
+    monkeypatch.setattr(auth.keyring, "set_password", fake_set_password)
+    monkeypatch.setattr(auth.keyring, "get_password", fake_get_password)
+    monkeypatch.setattr(auth.keyring, "delete_password", fake_delete_password)
+
+    auth.save_api_key("secret", "https://api.example.test/v1/")
+    assert auth.load_api_key("https://api.example.test/v1") == "stored-key"
+    auth.delete_api_key("https://api.example.test/v1")
+
+    assert calls == [
+        ("set", "celesto", "api_key:https://api.example.test/v1", "secret"),
+        ("get", "celesto", "api_key:https://api.example.test/v1"),
+        ("delete", "celesto", "api_key:https://api.example.test/v1"),
+    ]
+
+
+def test_get_api_key_uses_saved_key_after_env_and_dotenv_miss(
+    monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CELESTO_API_KEY", raising=False)
+    monkeypatch.setattr("celesto.deployment.load_api_key", lambda: "stored-key")
+
+    assert _get_api_key() == "stored-key"
+
+
+def test_get_api_key_prefers_explicit_value_over_saved_key(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("celesto.deployment.load_api_key", lambda: "stored-key")
+
+    assert _get_api_key(api_key="explicit-key") == "explicit-key"
+
+
+def test_login_validates_and_saves_key(monkeypatch):
+    runner = CliRunner()
+    events = []
+
+    def fake_validate_api_key(api_key: str, base_url: str | None = None) -> None:
+        events.append(("validate", api_key, base_url))
+
+    def fake_save_api_key(api_key: str, base_url: str | None = None) -> None:
+        events.append(("save", api_key, base_url))
+
+    monkeypatch.setattr(auth, "validate_api_key", fake_validate_api_key)
+    monkeypatch.setattr(auth, "save_api_key", fake_save_api_key)
+
+    result = runner.invoke(
+        auth.app,
+        ["login", "--api-key", "test-key", "--base-url", "https://api.example.test/v1"],
+    )
+
+    assert result.exit_code == 0
+    assert "Saved your Celesto API key" in result.output
+    assert events == [
+        ("validate", "test-key", "https://api.example.test/v1"),
+        ("save", "test-key", "https://api.example.test/v1"),
+    ]
+
+
+def test_status_reports_missing_saved_key(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr(auth, "load_api_key", lambda base_url=None: None)
+
+    result = runner.invoke(auth.app, ["status"])
+
+    assert result.exit_code == 0
+    assert "No saved API key was found. Run celesto auth login." in result.output
+
+
+def test_logout_removes_saved_key(monkeypatch):
+    runner = CliRunner()
+    deleted = []
+    monkeypatch.setattr(auth, "delete_api_key", lambda base_url=None: deleted.append(base_url))
+
+    result = runner.invoke(auth.app, ["logout", "--base-url", "https://api.example.test/v1"])
+
+    assert result.exit_code == 0
+    assert deleted == ["https://api.example.test/v1"]
+    assert "Removed your saved Celesto API key" in result.output

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -35,13 +35,16 @@ def test_auth_helpers_use_base_url_scoped_keyring(monkeypatch):
 
 
 def test_get_api_key_uses_saved_key_after_env_and_dotenv_miss(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, capsys
 ):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("CELESTO_API_KEY", raising=False)
     monkeypatch.setattr("celesto.deployment.load_api_key", lambda: "stored-key")
 
     assert _get_api_key() == "stored-key"
+    captured = capsys.readouterr()
+    assert "Key CELESTO_API_KEY not found in .env" not in captured.out
+    assert "Key CELESTO_API_KEY not found in .env" not in captured.err
 
 
 def test_get_api_key_prefers_explicit_value_over_saved_key(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Added `celesto auth login`, `celesto auth status`, and `celesto auth logout` for reusable CLI authentication
- Store API keys in the OS credential store via `keyring`, scoped by Celesto base URL
- Updated CLI/API-key resolution to reuse saved credentials after `--api-key`, env vars, and `.env`
- Added README guidance and tests for the new auth flow and secure-store fallback

## Testing
- `uv run celesto auth --help`
- `uv run celesto auth login --help`
- `uv run celesto auth status`
- `uv run ruff check .`
- `uv run pytest`
- `npm run lint`
- `npm test`