### PR TITLE
Polish README docs and align template defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,9 @@
 ## Project Overview
 
 Celesto SDK is a Python client + CLI for the Celesto AI platform. It provides:
-- A typed Python SDK (`Celesto`) for Deployments and GateKeeper.
-- A CLI (`celesto`) for deployment and A2A utilities.
+- A typed Python SDK (`Celesto`) for cloud computers, deployments, and Gatekeeper.
+- A CLI (`celesto`) for signing in and managing cloud computers.
+- Optional integrations for running OpenAI agents in Celesto or local SmolVM sandboxes.
 
 ## Repository Structure
 
@@ -13,6 +14,8 @@ celesto-sdk/
 ├── src/celesto/       # SDK + CLI source code
 │   ├── sdk/               # SDK client, exceptions, types
 │   ├── main.py            # CLI app entrypoint (typer)
+│   ├── auth.py            # CLI authentication helpers
+│   ├── computer.py        # CLI computer helpers
 │   ├── deployment.py      # CLI deployment helpers
 │   ├── a2a.py              # CLI A2A helpers
 │   └── proxy.py           # CLI MCP proxy helper
@@ -73,6 +76,7 @@ uv run pytest
 
 - Follow progressive disclosure of complexity.
 - Lead with outcomes, not implementation details.
+- Capability first, motivation second.
 - The first paragraph of every documentation page should be plain English with no jargon.
 - Assume the reader may be a beginner engineer or a non-developer.
 - Do not assume prior knowledge.
@@ -80,6 +84,40 @@ uv run pytest
 - Do not introduce a new concept unless the page truly needs it.
 - If a technical term is necessary, explain it immediately in simple language.
 - Prefer short, concrete sentences over dense explanations.
+- Define product terms where they first appear. Useful definitions: an AI agent
+  is software that can plan and run tasks; a harness is code that starts,
+  tests, or supervises an agent; a sandbox is a separate computer where an
+  agent can work; a session is one running connection to that computer.
+- For top-level docs, make sure a new reader can quickly understand what
+  Celesto is, what they can do with it, and where to start next.
+- Cover both SDK and CLI paths when both are part of the product surface.
+
+## Documentation Examples and Commands
+
+- Every code sample must be copy-pasteable and consistent with the current codebase.
+- Every command must be runnable as written, with correct filenames, flags,
+  prerequisites, and working-directory assumptions.
+- If a command depends on being in the repository, say so before using repo-relative paths.
+- Introduce required keys, IDs, names, or variables before using them in commands or code.
+- Keep quickstarts minimal: install, configure, then one working end-to-end action.
+- Do not make templates part of the default quickstart path. Celesto uses the
+  `scratch` template by default, which is basic minimal Ubuntu.
+- Introduce templates as a separate add-on concept for preinstalled tools. For
+  example, `coding-agent` can appear in a dedicated templates section, not as
+  the first way to create a computer.
+- Use one concept per code sample. If an example needs setup, execution, and
+  cleanup, split those steps or explain the variable that connects them.
+- Prefer examples that show the real user outcome, such as creating a computer
+  and running a command, over examples that expose internal mechanics.
+- When documenting CLI JSON output, explain that `--json` prints structured data
+  for scripts and automation.
+- When using generated resource names in CLI docs, show how the name is created
+  or say that it comes from `celesto computer create` or
+  `celesto computer list`.
+- When documenting OpenAI Agents examples, include both `CELESTO_API_KEY` and
+  `OPENAI_API_KEY` prerequisites before the Python example.
+- Avoid repeating the same link in the intro and footer unless the repeated link
+  materially improves navigation.
 
 ## User-Facing Errors and Warnings
 

--- a/README.md
+++ b/README.md
@@ -61,17 +61,15 @@ code does not read that saved CLI key; it reads `CELESTO_API_KEY` or the
 
 ## Create a Computer from Python
 
-This example creates a computer from the `coding-agent` template, runs one
-command, prints the output, and deletes the computer.
-
-A template is a ready-made setup. The `coding-agent` template includes common
-tools for coding tasks.
+This example creates a minimal Ubuntu computer, runs one command, prints the
+output, and deletes the computer. Celesto uses the `scratch` template by
+default.
 
 ```python
 from celesto import Celesto
 
 with Celesto() as client:
-    computer = client.computers.create(template_id="coding-agent")
+    computer = client.computers.create()
     try:
         print(f"Computer ready: {computer['name']}")
 
@@ -99,7 +97,7 @@ first command creates a computer and saves its generated name in
 
 ```bash
 COMPUTER_NAME=$(
-  celesto computer create --template coding-agent --json |
+  celesto computer create --json |
   python3 -c 'import json, sys; print(json.load(sys.stdin)["name"])'
 )
 ```
@@ -120,7 +118,7 @@ To open an interactive terminal, create a computer and save its name:
 
 ```bash
 COMPUTER_NAME=$(
-  celesto computer create --template coding-agent --json |
+  celesto computer create --json |
   python3 -c 'import json, sys; print(json.load(sys.stdin)["name"])'
 )
 ```
@@ -148,7 +146,7 @@ import { Celesto } from "@celestoai/sdk";
 
 const celesto = new Celesto({ token: process.env.CELESTO_API_KEY });
 
-const computer = await celesto.computers.create({ templateId: "coding-agent" });
+const computer = await celesto.computers.create();
 try {
   console.log(`Computer ready: ${computer.name}`);
 
@@ -173,7 +171,6 @@ from celesto import Celesto
 
 with Celesto() as client:
     computer = client.computers.create(
-        template_id="coding-agent",
         cpus=2,
         memory=2048,
         disk_size_mb=15360,
@@ -184,9 +181,15 @@ with Celesto() as client:
         client.computers.delete(computer["id"])
 ```
 
-Omit CPU, memory, or disk fields to use the selected template defaults.
+Omit CPU, memory, or disk fields to use the default size.
 
-### List Templates
+### Templates
+
+By default, Celesto uses `scratch`, a minimal Ubuntu computer. Use a template
+when you want a computer that already has extra tools installed. For example,
+`coding-agent` includes common tools for coding tasks.
+
+List available templates:
 
 ```python
 from celesto import Celesto
@@ -197,15 +200,26 @@ with Celesto() as client:
         print(template["id"], template["default_ram_mb"])
 ```
 
+Create a computer from a template:
+
+```python
+from celesto import Celesto
+
+with Celesto() as client:
+    computer = client.computers.create(template_id="coding-agent")
+    try:
+        print(computer["name"])
+    finally:
+        client.computers.delete(computer["id"])
+```
+
 ### Run a Command
 
 ```python
 from celesto import Celesto
 
 with Celesto() as client:
-    computer = client.computers.create(
-        template_id="coding-agent",
-    )
+    computer = client.computers.create()
     try:
         result = client.computers.exec(computer["id"], "ls -la", timeout=60)
         print(result["exit_code"])
@@ -235,8 +249,8 @@ with Celesto() as client:
 | `celesto auth login` | Save your API key for CLI commands |
 | `celesto auth status` | Check whether an API key is saved |
 | `celesto auth logout` | Remove your saved API key |
-| `celesto computer create [--template ID] [--cpus N] [--memory MB] [--disk-size-mb MB]` | Create a computer |
-| `celesto computer templates` | List available computer templates |
+| `celesto computer create [--cpus N] [--memory MB] [--disk-size-mb MB] [--template ID]` | Create a computer |
+| `celesto computer templates` | List templates with preinstalled tools |
 | `celesto computer list` | List your computers |
 | `celesto computer run NAME "command"` | Run a command on a computer |
 | `celesto computer ssh NAME` | Open an interactive terminal |
@@ -250,7 +264,7 @@ scripts and automation:
 ```bash
 celesto computer list --json
 celesto computer templates --json
-celesto computer create --template coding-agent --disk-size-mb 15360 --json
+celesto computer create --disk-size-mb 15360 --json
 ```
 
 `celesto computer ssh` is interactive and does not support JSON output.
@@ -297,10 +311,7 @@ import asyncio
 from agents import Runner
 from agents.run import RunConfig
 from agents.sandbox import SandboxAgent, SandboxRunConfig
-from celesto.integrations.openai_agents import (
-    CelestoSandboxClient,
-    CelestoSandboxClientOptions,
-)
+from celesto.integrations.openai_agents import CelestoSandboxClient
 
 
 async def main() -> None:
@@ -310,9 +321,7 @@ async def main() -> None:
     )
 
     client = CelestoSandboxClient()
-    session = await client.create(
-        options=CelestoSandboxClientOptions(template_id="coding-agent")
-    )
+    session = await client.create()
 
     try:
         async with session:
@@ -328,6 +337,11 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+If your agent needs common coding tools preinstalled, pass
+`options=CelestoSandboxClientOptions(template_id="coding-agent")` when you call
+`client.create()`. Import `CelestoSandboxClientOptions` from
+`celesto.integrations.openai_agents`.
 
 For local sandbox runs, use `SmolVMSandboxClient` and
 `SmolVMSandboxClientOptions` from `celesto.integrations.openai_agents`. SmolVM

--- a/js/README.md
+++ b/js/README.md
@@ -1,12 +1,26 @@
 # @celestoai/sdk
 
-Use this package to create Celesto computers from Node.js apps. Your code can
-start a computer, run commands in it, and delete it when the work is done.
+Use this package to run work in Celesto from a Node.js app. Your code can create
+a cloud computer, run commands in it, and delete it when the work is done.
 
-It includes:
+An AI agent is software that can plan and run tasks. A harness is the code that
+starts, tests, or supervises an agent.
 
-- **Computers** (`/v1/computers`) — create, manage, and interact with sandboxed virtual machines
-- **Gatekeeper** (`/v1/gatekeeper`) — delegated access to user resources
+Use this package when you want to:
+
+- Run an AI agent or harness in a clean computer.
+- Run shell commands from JavaScript or TypeScript.
+- Keep agent work separate from your laptop, server, or production system.
+- Ask a user to approve access to Google Drive through Gatekeeper.
+
+Gatekeeper is Celesto's access helper. It lets a user approve which external
+files or folders your app can use.
+
+## Requirements
+
+- Node.js 18 or newer.
+- A Celesto API key from [Celesto Settings](https://celesto.ai) under
+  **Settings > Security**.
 
 ## Install
 
@@ -14,80 +28,157 @@ It includes:
 npm install @celestoai/sdk
 ```
 
+Set your API key before running SDK examples:
+
+```bash
+export CELESTO_API_KEY="your-api-key"
+```
+
 ## Quickstart
 
-```ts
+Create a file named `quickstart.mjs`:
+
+```js
 import { Celesto } from "@celestoai/sdk";
 
-const celesto = new Celesto({
-  token: process.env.CELESTO_API_KEY,
-  // organizationId: "org_123", // optional, for JWTs with multiple orgs
-});
+const celesto = new Celesto({ token: process.env.CELESTO_API_KEY });
 
-// Computers
-const computer = await celesto.computers.create({ templateId: "coding-agent" });
-const result = await celesto.computers.exec(computer.id, "uname -a");
-console.log(result.stdout);
-await celesto.computers.delete(computer.id);
+const computer = await celesto.computers.create();
+try {
+  console.log(`Computer ready: ${computer.name}`);
+
+  const result = await celesto.computers.exec(computer.id, "uname -a");
+  console.log(result.stdout);
+} finally {
+  await celesto.computers.delete(computer.id);
+}
+```
+
+Run it:
+
+```bash
+node quickstart.mjs
 ```
 
 ## Computers
 
-Templates are ready-made computer setups. Choose one when you want a computer
-that already has the tools your agent needs.
+A computer is a temporary cloud machine for your app or agent. By default,
+Celesto creates a `scratch` computer, which is a minimal Ubuntu computer.
 
-### Lifecycle
+### Create with Custom Resources
 
-```ts
+Create a file named `create-computer.mjs`:
+
+```js
+import { Celesto } from "@celestoai/sdk";
+
+const celesto = new Celesto({ token: process.env.CELESTO_API_KEY });
+
 const computer = await celesto.computers.create({
-  templateId: "coding-agent",
   cpus: 2,
   memory: 2048,
   diskSizeMb: 15360,
 });
 
-await celesto.computers.stop(computer.id);
-await celesto.computers.start(computer.id);
-await celesto.computers.delete(computer.id);
-
-const { computers, count } = await celesto.computers.list();
+try {
+  console.log(computer.name);
+} finally {
+  await celesto.computers.delete(computer.id);
+}
 ```
 
-Omit CPU, memory, or disk fields to use the selected template defaults.
+Omit CPU, memory, or disk fields to use the default size.
 
-```ts
+### Templates
+
+Use a template when you want a computer that already has extra tools installed.
+For example, `coding-agent` includes common tools for coding tasks.
+
+List available templates:
+
+Create a file named `list-templates.mjs`:
+
+```js
+import { Celesto } from "@celestoai/sdk";
+
+const celesto = new Celesto({ token: process.env.CELESTO_API_KEY });
+
 const templates = await celesto.computers.listTemplates();
 for (const template of templates) {
   console.log(template.id, template.defaultRamMb);
 }
 ```
 
-### Running commands
+Create a computer from a template:
 
-```ts
-const result = await celesto.computers.exec(computer.id, "ls -la", { timeout: 60 });
-console.log(result.exitCode, result.stdout, result.stderr);
+```js
+import { Celesto } from "@celestoai/sdk";
+
+const celesto = new Celesto({ token: process.env.CELESTO_API_KEY });
+
+const computer = await celesto.computers.create({ templateId: "coding-agent" });
+try {
+  console.log(computer.name);
+} finally {
+  await celesto.computers.delete(computer.id);
+}
 ```
 
-### Terminal connection
+### Run a Command
 
-`getTerminalConnection()` resolves a computer name or ID and returns everything you need
-to open a WebSocket terminal with any library of your choice. No built-in WebSocket
-dependency — bring your own.
+Create a file named `run-command.mjs`:
 
-```ts
-const conn = await celesto.computers.getTerminalConnection("my-computer");
+```js
+import { Celesto } from "@celestoai/sdk";
 
-// Use any WebSocket library (ws, Node 22+ built-in, etc.)
-import WebSocket from "ws";
-const ws = new WebSocket(conn.url, { headers: conn.headers });
-ws.on("open", () => ws.send(conn.firstMessage));
-ws.on("message", (data) => process.stdout.write(data));
+const celesto = new Celesto({ token: process.env.CELESTO_API_KEY });
+
+const computer = await celesto.computers.create();
+try {
+  const result = await celesto.computers.exec(computer.id, "ls -la", {
+    timeout: 60,
+  });
+
+  console.log(result.exitCode);
+  console.log(result.stdout);
+  console.error(result.stderr);
+} finally {
+  await celesto.computers.delete(computer.id);
+}
 ```
+
+### Manage Computers
+
+`computerId` can be the ID returned by `celesto.computers.create()` or a
+computer name shown by the Celesto command-line tool:
+`celesto computer list`.
+
+| Method | What it does |
+| --- | --- |
+| `celesto.computers.list()` | List computers in your account |
+| `celesto.computers.get(computerId)` | Get one computer by name or ID |
+| `celesto.computers.stop(computerId)` | Stop a running computer |
+| `celesto.computers.start(computerId)` | Start a stopped computer |
+| `celesto.computers.delete(computerId)` | Delete a computer |
+
+### Terminal Connections
+
+Use `getTerminalConnection()` when you are building your own interactive
+terminal. It returns the WebSocket URL, headers, and first message needed to
+connect. A WebSocket is a long-running connection for sending terminal input and
+receiving terminal output.
+
+The SDK does not install a WebSocket package for you. Use any WebSocket library
+that supports custom headers.
 
 ## Gatekeeper
 
-```ts
+Use Gatekeeper when your app needs user-approved access to an external resource,
+such as Google Drive.
+
+Create a file named `gatekeeper-connect.mjs`:
+
+```js
 import { GatekeeperClient } from "@celestoai/sdk/gatekeeper";
 
 const client = new GatekeeperClient({ token: process.env.CELESTO_API_KEY });
@@ -99,18 +190,52 @@ const connect = await client.connect({
 });
 
 if (connect.status === "redirect") {
-  console.log("OAuth URL:", connect.oauthUrl);
+  console.log(connect.oauthUrl);
+} else {
+  console.log(connect.status);
 }
 ```
 
-Full docs: https://docs.celesto.ai/celesto-sdk/gatekeeper
+If the response prints a URL, open it so the user can approve access.
 
-## Notes
+Full Gatekeeper docs: https://docs.celesto.ai/celesto-sdk/gatekeeper
 
-- `token` accepts either a Celesto API key or a JWT.
-- `organizationId` adds the `X-Current-Organization` header.
-- Requires Node 18+ for built-in `fetch`. Zero runtime dependencies.
+## Configuration
+
+| Option | What it does |
+| --- | --- |
+| `token` | Celesto API key or JWT |
+| `apiKey` | Alias for `token` |
+| `baseUrl` | Custom Celesto API URL |
+| `organizationId` | Sends the `X-Current-Organization` header |
+| `timeoutMs` | Request timeout in milliseconds |
+| `headers` | Extra headers to send with every request |
+
+A JWT is a signed login token. Most users should use a Celesto API key.
+
+## Errors
+
+The SDK exports these error classes:
+
+| Error | When it is used |
+| --- | --- |
+| `CelestoApiError` | The API returns an error status |
+| `CelestoNetworkError` | The network request fails |
+| `CelestoError` | Base class for all SDK errors |
+
+## Develop Locally
+
+If you are contributing and have `npm` installed, run these commands from the
+repository's `js` directory:
+
+```bash
+npm install
+npm test
+npm run lint
+npm run build
+```
 
 ## License
 
-Apache-2.0. The SDK is open source; use of the Celesto platform is governed by the Celesto Terms of Service: https://celesto.ai/legal/terms
+Apache-2.0. The SDK is open source. Use of the Celesto platform is governed by
+the Celesto Terms of Service: https://celesto.ai/legal/terms

--- a/js/README.md
+++ b/js/README.md
@@ -62,7 +62,7 @@ node quickstart.mjs
 
 ## Computers
 
-A computer is a temporary cloud machine for your app or agent. By default,
+A computer is a disposable cloud machine for your app or agent. By default,
 Celesto creates a `scratch` computer, which is a minimal Ubuntu computer.
 
 ### Create with Custom Resources
@@ -211,7 +211,7 @@ Full Gatekeeper docs: https://docs.celesto.ai/celesto-sdk/gatekeeper
 | `timeoutMs` | Request timeout in milliseconds |
 | `headers` | Extra headers to send with every request |
 
-A JWT is a signed login token. Most users should use a Celesto API key.
+JWT is a signed login token. Most users should use a Celesto API key.
 
 ## Errors
 

--- a/js/src/computers/client.ts
+++ b/js/src/computers/client.ts
@@ -153,7 +153,7 @@ const pickOverrides = (options?: RequestOverrides): RequestOverrides => ({
  * @example
  * ```ts
  * const celesto = new Celesto({ token: process.env.CELESTO_API_KEY });
- * const computer = await celesto.computers.create({ templateId: "coding-agent" });
+ * const computer = await celesto.computers.create();
  * const result = await celesto.computers.exec(computer.id, "uname -a");
  * console.log(result.stdout);
  * await celesto.computers.delete(computer.id);

--- a/src/celesto/integrations/openai_agents/hosted.py
+++ b/src/celesto/integrations/openai_agents/hosted.py
@@ -36,7 +36,7 @@ class CelestoSandboxClientOptions(BaseSandboxClientOptions):
     memory: int | None = None
     disk_size_mb: int | None = None
     image: str | None = None
-    template_id: str | None = "coding-agent"
+    template_id: str | None = None
     template_version: str | None = None
     start_timeout_seconds: float = 120
     start_poll_interval_seconds: float = 2
@@ -52,7 +52,7 @@ class CelestoSandboxSessionState(SandboxSessionState):
     memory: int | None = None
     disk_size_mb: int | None = None
     image: str | None = None
-    template_id: str | None = "coding-agent"
+    template_id: str | None = None
     template_version: str | None = None
     start_timeout_seconds: float = 120
     start_poll_interval_seconds: float = 2

--- a/src/celesto/sdk/client.py
+++ b/src/celesto/sdk/client.py
@@ -795,7 +795,7 @@ class Computers(_BaseClient):
 
     Example:
         >>> with Celesto() as client:
-        ...     computer = client.computers.create(template_id="coding-agent")
+        ...     computer = client.computers.create()
         ...     result = client.computers.exec(computer["id"], "uname -a")
         ...     print(result["stdout"])
         ...     client.computers.delete(computer["id"])
@@ -815,8 +815,8 @@ class Computers(_BaseClient):
     ) -> dict[str, Any]:
         """Create a new sandboxed computer.
 
-        Resource fields are optional. If omitted, the backend applies the
-        selected template's defaults.
+        Resource fields are optional. If omitted, Celesto creates a scratch
+        computer with the default size.
 
         Args:
             cpus: Number of virtual CPUs (1-16). Alias for vcpus.
@@ -826,7 +826,7 @@ class Computers(_BaseClient):
             disk_size_mb: Disk size in MB (512-51200).
             image: Legacy OS image selector.
             template_id: Sandbox template id, such as "scratch" or
-                "coding-agent".
+                "coding-agent". Use this when you want preinstalled tools.
             template_version: Optional immutable template version.
 
         Returns:


### PR DESCRIPTION
## Summary
- Updated the Python, JS/TS, and project guidance docs to treat `scratch` as the default computer and templates as an add-on for preinstalled tools.
- Reworked quickstarts so the default path creates a computer without `template_id` / `templateId`, and moved `coding-agent` into dedicated template sections.
- Aligned the OpenAI hosted sandbox defaults and refreshed related SDK doc examples and comments to match the new framing.

## Testing
- `uv run pytest` passed.
- `uv run ruff check .` passed.
- `npm run lint` passed.
- `npm run build` passed.
- `npm test` passed.