### PR TITLE
Fix SSH terminal resize dimensions

### DIFF
--- a/src/celesto/computer.py
+++ b/src/celesto/computer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from typing import Optional
 
@@ -28,6 +29,12 @@ JsonOption = Annotated[
     bool,
     typer.Option("--json", "-j", help="Output as JSON (for machines and AI agents)"),
 ]
+
+
+def _terminal_dimensions() -> tuple[int, int]:
+    """Return terminal size as rows, columns."""
+    size = os.get_terminal_size()
+    return size.lines, size.columns
 
 
 def _get_client(api_key: str | None = None) -> Celesto:
@@ -348,7 +355,6 @@ def ssh_to_computer(
     api_key: ApiKeyOption = None,
 ):
     """Open an interactive terminal session on a computer. Automatically resumes stopped computers."""
-    import os
     import signal
     import termios
     import threading
@@ -393,7 +399,7 @@ def ssh_to_computer(
 
     ws.send(json.dumps({"token": key}))
 
-    rows, cols = os.get_terminal_size()
+    rows, cols = _terminal_dimensions()
     ws.send(json.dumps({"type": "resize", "cols": cols, "rows": rows}))
 
     console.print("[dim]Connected. Press Ctrl+] to disconnect.[/dim]")
@@ -426,7 +432,7 @@ def ssh_to_computer(
     def handle_sigwinch(*_args):
         nonlocal rows, cols
         try:
-            new_rows, new_cols = os.get_terminal_size()
+            new_rows, new_cols = _terminal_dimensions()
             if (new_rows, new_cols) != (rows, cols):
                 rows, cols = new_rows, new_cols
                 ws.send(json.dumps({"type": "resize", "cols": cols, "rows": rows}))

--- a/tests/test_computer_cli.py
+++ b/tests/test_computer_cli.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
 import json
+import os
 from urllib.parse import urlparse
 
 from typer.testing import CliRunner
 
 from celesto import computer
+
+
+def test_terminal_dimensions_return_rows_then_columns(monkeypatch):
+    monkeypatch.setattr(
+        computer.os,
+        "get_terminal_size",
+        lambda: os.terminal_size((120, 30)),
+    )
+
+    assert computer._terminal_dimensions() == (30, 120)
 
 
 class _FakeComputers:


### PR DESCRIPTION
## Summary
- Correct the SSH terminal resize payload so `rows` and `cols` are sent in the right order.
- Add a small helper to normalize terminal dimensions before sending resize events.
- Add a regression test to cover the dimension conversion.

## Testing
- `uv run pytest tests/test_computer_cli.py`
- `uv run ruff check src/celesto/computer.py tests/test_computer_cli.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved terminal size handling for SSH connections with enhanced code organization.

* **Tests**
  * Added unit test coverage for terminal dimension detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->