### PR TITLE
Add a pip-aware celesto update command

### DIFF
--- a/src/celesto/main.py
+++ b/src/celesto/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from shutil import which
 
 import typer
 from rich import print
@@ -16,9 +17,37 @@ app.add_typer(auth.app, name="auth")
 app.add_typer(computer.app, name="computer")
 
 
-def _run_pip_update() -> None:
+def _has_pip() -> bool:
+    return (
+        subprocess.run(
+            [sys.executable, "-m", "pip", "--version"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode
+        == 0
+    )
+
+
+def _run_update() -> None:
+    if _has_pip():
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--upgrade", "celesto"],
+            check=True,
+        )
+        return
+
+    uv = which("uv")
+    if uv is None:
+        raise RuntimeError(
+            "This Python environment does not have pip. "
+            "Install pip or run uv pip install --python "
+            f"{sys.executable} --upgrade celesto."
+        )
+
+    print("pip is not installed in this environment. Using uv instead...")
     subprocess.run(
-        [sys.executable, "-m", "pip", "install", "--upgrade", "celesto"],
+        [uv, "pip", "install", "--python", sys.executable, "--upgrade", "celesto"],
         check=True,
     )
 
@@ -28,12 +57,15 @@ def update() -> None:
     """Update Celesto to the newest version available from pip."""
     print("Checking for a newer Celesto version...")
     try:
-        _run_pip_update()
+        _run_update()
     except subprocess.CalledProcessError:
         print(
             "[red]Could not update Celesto. "
-            "Run python -m pip install --upgrade celesto.[/red]"
+            f"Run uv pip install --python {sys.executable} --upgrade celesto.[/red]"
         )
+        raise typer.Exit(1) from None
+    except RuntimeError as exc:
+        print(f"[red]{exc}[/red]")
         raise typer.Exit(1) from None
     print("Celesto is up to date or has been updated.")
 

--- a/src/celesto/main.py
+++ b/src/celesto/main.py
@@ -46,7 +46,7 @@ def _run_update() -> None:
         )
 
     print("pip is not installed in this environment. Using uv instead...")
-    subprocess.run(
+    subprocess.run(  # noqa: S603
         [uv, "pip", "install", "--python", sys.executable, "--upgrade", "celesto"],
         check=True,
     )

--- a/src/celesto/main.py
+++ b/src/celesto/main.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import subprocess
+import sys
+
 import typer
 from rich import print
 
@@ -11,6 +14,28 @@ app = typer.Typer(
 )
 app.add_typer(auth.app, name="auth")
 app.add_typer(computer.app, name="computer")
+
+
+def _run_pip_update() -> None:
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--upgrade", "celesto"],
+        check=True,
+    )
+
+
+@app.command("update")
+def update() -> None:
+    """Update Celesto to the newest version available from pip."""
+    print("Checking for a newer Celesto version...")
+    try:
+        _run_pip_update()
+    except subprocess.CalledProcessError:
+        print(
+            "[red]Could not update Celesto. "
+            "Run python -m pip install --upgrade celesto.[/red]"
+        )
+        raise typer.Exit(1) from None
+    print("Celesto is up to date or has been updated.")
 
 
 @app.callback(invoke_without_command=True)

--- a/tests/test_update_cli.py
+++ b/tests/test_update_cli.py
@@ -7,11 +7,21 @@ from typer.testing import CliRunner
 from celesto import main
 
 
+def _one_line(text: str) -> str:
+    return " ".join(text.split())
+
+
 def test_update_runs_pip_upgrade(monkeypatch):
     runner = CliRunner()
     calls: list[tuple[list[str], bool]] = []
 
-    def fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess:
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        stdout: int | None = None,
+        stderr: int | None = None,
+    ) -> subprocess.CompletedProcess:
         calls.append((command, check))
         return subprocess.CompletedProcess(command, 0)
 
@@ -22,21 +32,100 @@ def test_update_runs_pip_upgrade(monkeypatch):
 
     assert result.exit_code == 0
     assert calls == [
-        (["/usr/bin/python", "-m", "pip", "install", "--upgrade", "celesto"], True)
+        (["/usr/bin/python", "-m", "pip", "--version"], False),
+        (["/usr/bin/python", "-m", "pip", "install", "--upgrade", "celesto"], True),
     ]
     assert "Celesto is up to date or has been updated." in result.output
 
 
-def test_update_prints_recovery_command_when_pip_fails(monkeypatch):
+def test_update_uses_uv_when_pip_is_missing(monkeypatch):
+    runner = CliRunner()
+    calls: list[tuple[list[str], bool]] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        stdout: int | None = None,
+        stderr: int | None = None,
+    ) -> subprocess.CompletedProcess:
+        calls.append((command, check))
+        return subprocess.CompletedProcess(
+            command, 1 if command[-1] == "--version" else 0
+        )
+
+    monkeypatch.setattr(main.sys, "executable", "/workspace/.venv/bin/python")
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+    monkeypatch.setattr(main, "which", lambda command: "/usr/local/bin/uv")
+
+    result = runner.invoke(main.app, ["update"])
+
+    assert result.exit_code == 0
+    assert calls == [
+        (["/workspace/.venv/bin/python", "-m", "pip", "--version"], False),
+        (
+            [
+                "/usr/local/bin/uv",
+                "pip",
+                "install",
+                "--python",
+                "/workspace/.venv/bin/python",
+                "--upgrade",
+                "celesto",
+            ],
+            True,
+        ),
+    ]
+    assert "Using uv instead" in result.output
+
+
+def test_update_prints_recovery_command_when_update_fails(monkeypatch):
     runner = CliRunner()
 
-    def fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess:
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        stdout: int | None = None,
+        stderr: int | None = None,
+    ) -> subprocess.CompletedProcess:
+        if command[-1] == "--version":
+            return subprocess.CompletedProcess(command, 0)
         raise subprocess.CalledProcessError(1, command)
 
+    monkeypatch.setattr(main.sys, "executable", "/usr/bin/python")
     monkeypatch.setattr(main.subprocess, "run", fake_run)
 
     result = runner.invoke(main.app, ["update"])
 
     assert result.exit_code == 1
     assert "Could not update Celesto." in result.output
-    assert "python -m pip install --upgrade celesto" in result.output
+    assert "uv pip install --python /usr/bin/python --upgrade celesto" in _one_line(
+        result.output
+    )
+
+
+def test_update_explains_when_pip_and_uv_are_missing(monkeypatch):
+    runner = CliRunner()
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        stdout: int | None = None,
+        stderr: int | None = None,
+    ) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(command, 1)
+
+    monkeypatch.setattr(main.sys, "executable", "/workspace/.venv/bin/python")
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+    monkeypatch.setattr(main, "which", lambda command: None)
+
+    result = runner.invoke(main.app, ["update"])
+
+    assert result.exit_code == 1
+    assert "This Python environment does not have pip." in result.output
+    assert (
+        "uv pip install --python /workspace/.venv/bin/python --upgrade celesto"
+        in _one_line(result.output)
+    )

--- a/tests/test_update_cli.py
+++ b/tests/test_update_cli.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import subprocess
+
+from typer.testing import CliRunner
+
+from celesto import main
+
+
+def test_update_runs_pip_upgrade(monkeypatch):
+    runner = CliRunner()
+    calls: list[tuple[list[str], bool]] = []
+
+    def fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess:
+        calls.append((command, check))
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(main.sys, "executable", "/usr/bin/python")
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+
+    result = runner.invoke(main.app, ["update"])
+
+    assert result.exit_code == 0
+    assert calls == [
+        (["/usr/bin/python", "-m", "pip", "install", "--upgrade", "celesto"], True)
+    ]
+    assert "Celesto is up to date or has been updated." in result.output
+
+
+def test_update_prints_recovery_command_when_pip_fails(monkeypatch):
+    runner = CliRunner()
+
+    def fake_run(command: list[str], *, check: bool) -> subprocess.CompletedProcess:
+        raise subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+
+    result = runner.invoke(main.app, ["update"])
+
+    assert result.exit_code == 1
+    assert "Could not update Celesto." in result.output
+    assert "python -m pip install --upgrade celesto" in result.output


### PR DESCRIPTION
## Summary
- Add a top-level `celesto update` command that upgrades Celesto in the current Python environment.
- Fall back to `uv pip install --python <current-python> --upgrade celesto` when `pip` is not available, which covers `uv run` environments.
- Add tests for the pip path, the uv fallback, and the failure messages.

## Testing
- Unit tests added for the new update command behavior.
- `uv run pytest` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an `update` CLI command enabling package updates with intelligent fallback mechanisms and clear guidance when updates encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->