### PR TITLE
Support auth login without system keyring

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ celesto auth login
 
 The CLI stores the key in your operating system's secure credential store. On
 Linux machines without a credential store, it saves the key in
-`~/.config/celesto/credentials.json` with user-only file permissions. SDK code
-does not read that saved CLI key; it reads `CELESTO_API_KEY` or the `api_key`
-value you pass to `Celesto`.
+`$XDG_CONFIG_HOME/celesto/credentials.json` when `XDG_CONFIG_HOME` is set, or
+`~/.config/celesto/credentials.json` otherwise, with user-only file
+permissions. SDK code does not read that saved CLI key; it reads
+`CELESTO_API_KEY` or the `api_key` value you pass to `Celesto`.
 
 ## Create a Computer from Python
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ For CLI commands, you can save the key once:
 celesto auth login
 ```
 
-The CLI stores the key in your operating system's secure credential store. SDK
-code does not read that saved CLI key; it reads `CELESTO_API_KEY` or the
-`api_key` value you pass to `Celesto`.
+The CLI stores the key in your operating system's secure credential store. On
+Linux machines without a credential store, it saves the key in
+`~/.config/celesto/credentials.json` with user-only file permissions. SDK code
+does not read that saved CLI key; it reads `CELESTO_API_KEY` or the `api_key`
+value you pass to `Celesto`.
 
 ## Create a Computer from Python
 

--- a/src/celesto/auth.py
+++ b/src/celesto/auth.py
@@ -18,6 +18,7 @@ from .sdk.client import Celesto
 DEFAULT_BASE_URL = "https://api.celesto.ai/v1"
 KEYRING_SERVICE = "celesto"
 CREDENTIALS_FILE_NAME = "credentials.json"
+CREDENTIAL_STORE_PREFERENCE_KEY = "__credential_store_preference__"
 
 app = typer.Typer(help="Sign in and manage saved credentials.")
 console = Console()
@@ -50,6 +51,7 @@ def _credential_file_path() -> Path:
 
 
 def _load_file_credentials() -> dict[str, str]:
+    """Load credentials from file, including the store preference marker."""
     credentials_path = _credential_file_path()
     if not credentials_path.exists():
         return {}
@@ -105,6 +107,26 @@ def _delete_file_credential(account: str) -> None:
         return
 
 
+def _get_credential_store_preference(account: str) -> Literal["keyring", "file"] | None:
+    """Get the preferred credential store for this account."""
+    credentials = _load_file_credentials()
+    pref_key = f"{CREDENTIAL_STORE_PREFERENCE_KEY}:{account}"
+    pref = credentials.get(pref_key)
+    if pref in ("keyring", "file"):
+        return pref
+    return None
+
+
+def _set_credential_store_preference(
+    account: str, store: Literal["keyring", "file"]
+) -> None:
+    """Record which credential store was last used successfully for this account."""
+    credentials = _load_file_credentials()
+    pref_key = f"{CREDENTIAL_STORE_PREFERENCE_KEY}:{account}"
+    credentials[pref_key] = store
+    _save_file_credentials(credentials)
+
+
 def save_api_key(
     api_key: str, base_url: str | None = None
 ) -> Literal["keyring", "file"]:
@@ -117,11 +139,13 @@ def save_api_key(
             account,
             api_key,
         )
+        _set_credential_store_preference(account, "keyring")
         return "keyring"
     except Exception:
         credentials = _load_file_credentials()
         credentials[account] = api_key
         _save_file_credentials(credentials)
+        _set_credential_store_preference(account, "file")
         return "file"
 
 
@@ -129,6 +153,22 @@ def load_api_key(base_url: str | None = None) -> str | None:
     """Load a saved API key for CLI commands."""
     resolved_base_url = _resolve_base_url(base_url)
     account = _credential_account(resolved_base_url)
+
+    # Check which store was last used successfully
+    preference = _get_credential_store_preference(account)
+
+    if preference == "file":
+        # File was last used successfully, try file first
+        file_key = _load_file_credentials().get(account)
+        if file_key is not None:
+            return file_key
+        # Fall back to keyring if file doesn't have it
+        try:
+            return keyring.get_password(KEYRING_SERVICE, account)
+        except Exception:
+            return None
+
+    # No preference or keyring preference: try keyring first
     try:
         saved_api_key = keyring.get_password(
             KEYRING_SERVICE,
@@ -143,9 +183,11 @@ def load_api_key(base_url: str | None = None) -> str | None:
 
 
 def delete_api_key(base_url: str | None = None) -> None:
-    """Delete a saved API key for CLI commands."""
+    """Delete a saved API key from both stores and clear the preference."""
     resolved_base_url = _resolve_base_url(base_url)
     account = _credential_account(resolved_base_url)
+
+    # Delete from keyring
     try:
         keyring.delete_password(
             KEYRING_SERVICE,
@@ -153,7 +195,23 @@ def delete_api_key(base_url: str | None = None) -> None:
         )
     except Exception:
         pass
+
+    # Delete from file
     _delete_file_credential(account)
+
+    # Clear the preference marker
+    credentials = _load_file_credentials()
+    pref_key = f"{CREDENTIAL_STORE_PREFERENCE_KEY}:{account}"
+    if pref_key in credentials:
+        del credentials[pref_key]
+        if credentials:
+            _save_file_credentials(credentials)
+        else:
+            # No more credentials, clean up the file
+            try:
+                _credential_file_path().unlink()
+            except FileNotFoundError:
+                pass
 
 
 def validate_api_key(api_key: str, base_url: str | None = None) -> None:

--- a/src/celesto/auth.py
+++ b/src/celesto/auth.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 import keyring
 import typer
+from keyring.errors import KeyringError
 from rich.console import Console
 from typing_extensions import Annotated
 
@@ -141,7 +142,7 @@ def save_api_key(
         )
         _set_credential_store_preference(account, "keyring")
         return "keyring"
-    except Exception:
+    except KeyringError:
         credentials = _load_file_credentials()
         credentials[account] = api_key
         _save_file_credentials(credentials)
@@ -165,7 +166,8 @@ def load_api_key(base_url: str | None = None) -> str | None:
         # Fall back to keyring if file doesn't have it
         try:
             return keyring.get_password(KEYRING_SERVICE, account)
-        except Exception:
+        except KeyringError:
+            # The file preference is already missing; treat keyring failure as no saved key.
             return None
 
     # No preference or keyring preference: try keyring first
@@ -176,7 +178,8 @@ def load_api_key(base_url: str | None = None) -> str | None:
         )
         if saved_api_key is not None:
             return saved_api_key
-    except Exception:
+    except KeyringError:
+        # Missing or unavailable keyring is expected on headless Linux; try file storage next.
         pass
 
     return _load_file_credentials().get(account)
@@ -193,7 +196,8 @@ def delete_api_key(base_url: str | None = None) -> None:
             KEYRING_SERVICE,
             account,
         )
-    except Exception:
+    except KeyringError:
+        # Logout should still remove file credentials even when the OS keyring is unavailable.
         pass
 
     # Delete from file

--- a/src/celesto/auth.py
+++ b/src/celesto/auth.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Literal
 
 import keyring
 import typer
-from keyring.errors import KeyringError
 from rich.console import Console
 from typing_extensions import Annotated
 
@@ -14,6 +17,7 @@ from .sdk.client import Celesto
 
 DEFAULT_BASE_URL = "https://api.celesto.ai/v1"
 KEYRING_SERVICE = "celesto"
+CREDENTIALS_FILE_NAME = "credentials.json"
 
 app = typer.Typer(help="Sign in and manage saved credentials.")
 console = Console()
@@ -38,38 +42,118 @@ def _resolve_base_url(base_url: str | None = None) -> str:
     )
 
 
-def save_api_key(api_key: str, base_url: str | None = None) -> None:
-    """Save an API key in the operating system's secure credential store."""
+def _credential_file_path() -> Path:
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home:
+        return Path(config_home) / "celesto" / CREDENTIALS_FILE_NAME
+    return Path.home() / ".config" / "celesto" / CREDENTIALS_FILE_NAME
+
+
+def _load_file_credentials() -> dict[str, str]:
+    credentials_path = _credential_file_path()
+    if not credentials_path.exists():
+        return {}
+
+    try:
+        data = json.loads(credentials_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    credentials: dict[str, str] = {}
+    for account, api_key in data.items():
+        if isinstance(account, str) and isinstance(api_key, str):
+            credentials[account] = api_key
+    return credentials
+
+
+def _save_file_credentials(credentials: dict[str, str]) -> None:
+    credentials_path = _credential_file_path()
+    credentials_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    credentials_path.parent.chmod(0o700)
+
+    with NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=credentials_path.parent,
+        delete=False,
+    ) as temp_file:
+        json.dump(credentials, temp_file, indent=2, sort_keys=True)
+        temp_file.write("\n")
+        temp_path = Path(temp_file.name)
+
+    temp_path.chmod(0o600)
+    temp_path.replace(credentials_path)
+
+
+def _delete_file_credential(account: str) -> None:
+    credentials = _load_file_credentials()
+    if account not in credentials:
+        return
+
+    del credentials[account]
+    credentials_path = _credential_file_path()
+    if credentials:
+        _save_file_credentials(credentials)
+        return
+
+    try:
+        credentials_path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def save_api_key(
+    api_key: str, base_url: str | None = None
+) -> Literal["keyring", "file"]:
+    """Save an API key for future CLI commands."""
     resolved_base_url = _resolve_base_url(base_url)
-    keyring.set_password(
-        KEYRING_SERVICE,
-        _credential_account(resolved_base_url),
-        api_key,
-    )
+    account = _credential_account(resolved_base_url)
+    try:
+        keyring.set_password(
+            KEYRING_SERVICE,
+            account,
+            api_key,
+        )
+        return "keyring"
+    except Exception:
+        credentials = _load_file_credentials()
+        credentials[account] = api_key
+        _save_file_credentials(credentials)
+        return "file"
 
 
 def load_api_key(base_url: str | None = None) -> str | None:
-    """Load a saved API key from the operating system's secure credential store."""
+    """Load a saved API key for CLI commands."""
     resolved_base_url = _resolve_base_url(base_url)
+    account = _credential_account(resolved_base_url)
     try:
-        return keyring.get_password(
+        saved_api_key = keyring.get_password(
             KEYRING_SERVICE,
-            _credential_account(resolved_base_url),
+            account,
         )
-    except KeyringError:
-        return None
+        if saved_api_key is not None:
+            return saved_api_key
+    except Exception:
+        pass
+
+    return _load_file_credentials().get(account)
 
 
 def delete_api_key(base_url: str | None = None) -> None:
-    """Delete a saved API key from the operating system's secure credential store."""
+    """Delete a saved API key for CLI commands."""
     resolved_base_url = _resolve_base_url(base_url)
+    account = _credential_account(resolved_base_url)
     try:
         keyring.delete_password(
             KEYRING_SERVICE,
-            _credential_account(resolved_base_url),
+            account,
         )
-    except KeyringError:
-        return
+    except Exception:
+        pass
+    _delete_file_credential(account)
 
 
 def validate_api_key(api_key: str, base_url: str | None = None) -> None:
@@ -104,20 +188,27 @@ def login(
     try:
         validate_api_key(api_key, resolved_base_url)
     except Exception as exc:
-        console.print("That API key did not work. Check it and run celesto auth login again.")
-        raise typer.Exit(1) from exc
-
-    try:
-        save_api_key(api_key, resolved_base_url)
-    except KeyringError as exc:
         console.print(
-            "Your API key could not be saved securely. Set CELESTO_API_KEY and try your command again."
+            "That API key did not work. Check it and run celesto auth login again."
         )
         raise typer.Exit(1) from exc
 
-    console.print(
-        "Saved your Celesto API key. You can now run commands like celesto computer list."
-    )
+    try:
+        credential_store = save_api_key(api_key, resolved_base_url)
+    except OSError as exc:
+        console.print(
+            "Your API key could not be saved. Set CELESTO_API_KEY and try your command again."
+        )
+        raise typer.Exit(1) from exc
+
+    if credential_store == "file":
+        console.print(
+            "Saved your Celesto API key in a local credentials file. You can now run commands like celesto computer list."
+        )
+    else:
+        console.print(
+            "Saved your Celesto API key. You can now run commands like celesto computer list."
+        )
 
 
 @app.command("status")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,8 +9,10 @@ from celesto import auth
 from celesto.deployment import _get_api_key
 
 
-def test_auth_helpers_use_base_url_scoped_keyring(monkeypatch):
+def test_auth_helpers_use_base_url_scoped_keyring(monkeypatch, tmp_path):
     calls = []
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     def fake_set_password(service: str, account: str, password: str) -> None:
         calls.append(("set", service, account, password))
@@ -49,11 +51,13 @@ def test_auth_helpers_fall_back_to_local_credentials_file(monkeypatch, tmp_path)
     store = auth.save_api_key("secret", "https://api.example.test/v1/")
 
     credentials_path = tmp_path / "celesto" / "credentials.json"
+    credentials = json.loads(credentials_path.read_text(encoding="utf-8"))
+    account = "api_key:https://api.example.test/v1"
+
     assert store == "file"
     assert credentials_path.stat().st_mode & 0o777 == 0o600
-    assert json.loads(credentials_path.read_text(encoding="utf-8")) == {
-        "api_key:https://api.example.test/v1": "secret"
-    }
+    assert credentials[account] == "secret"
+    assert credentials[f"{auth.CREDENTIAL_STORE_PREFERENCE_KEY}:{account}"] == "file"
     assert auth.load_api_key("https://api.example.test/v1") == "secret"
 
     auth.delete_api_key("https://api.example.test/v1")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+
+from keyring.errors import KeyringError
 from typer.testing import CliRunner
 
 from celesto import auth
@@ -32,6 +35,73 @@ def test_auth_helpers_use_base_url_scoped_keyring(monkeypatch):
         ("get", "celesto", "api_key:https://api.example.test/v1"),
         ("delete", "celesto", "api_key:https://api.example.test/v1"),
     ]
+
+
+def test_auth_helpers_fall_back_to_local_credentials_file(monkeypatch, tmp_path):
+    def raise_keyring_error(*args: object, **kwargs: object) -> None:
+        raise KeyringError("no keyring backend")
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(auth.keyring, "set_password", raise_keyring_error)
+    monkeypatch.setattr(auth.keyring, "get_password", raise_keyring_error)
+    monkeypatch.setattr(auth.keyring, "delete_password", raise_keyring_error)
+
+    store = auth.save_api_key("secret", "https://api.example.test/v1/")
+
+    credentials_path = tmp_path / "celesto" / "credentials.json"
+    assert store == "file"
+    assert credentials_path.stat().st_mode & 0o777 == 0o600
+    assert json.loads(credentials_path.read_text(encoding="utf-8")) == {
+        "api_key:https://api.example.test/v1": "secret"
+    }
+    assert auth.load_api_key("https://api.example.test/v1") == "secret"
+
+    auth.delete_api_key("https://api.example.test/v1")
+
+    assert not credentials_path.exists()
+
+
+def test_login_uses_file_fallback_when_keyring_is_unavailable(monkeypatch, tmp_path):
+    runner = CliRunner()
+
+    def raise_keyring_error(*args: object, **kwargs: object) -> None:
+        raise KeyringError("no keyring backend")
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(auth, "validate_api_key", lambda api_key, base_url=None: None)
+    monkeypatch.setattr(auth.keyring, "set_password", raise_keyring_error)
+
+    result = runner.invoke(
+        auth.app,
+        ["login", "--api-key", "test-key", "--base-url", "https://api.example.test/v1"],
+    )
+
+    assert result.exit_code == 0
+    assert "Saved your Celesto API key in a local credentials file" in result.output
+    assert auth.load_api_key("https://api.example.test/v1") == "test-key"
+
+
+def test_login_reports_when_key_cannot_be_saved(monkeypatch, tmp_path):
+    runner = CliRunner()
+
+    def raise_keyring_error(*args: object, **kwargs: object) -> None:
+        raise KeyringError("no keyring backend")
+
+    def raise_os_error(*args: object, **kwargs: object) -> None:
+        raise OSError("read-only config")
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(auth, "validate_api_key", lambda api_key, base_url=None: None)
+    monkeypatch.setattr(auth.keyring, "set_password", raise_keyring_error)
+    monkeypatch.setattr(auth, "_save_file_credentials", raise_os_error)
+
+    result = runner.invoke(
+        auth.app,
+        ["login", "--api-key", "test-key", "--base-url", "https://api.example.test/v1"],
+    )
+
+    assert result.exit_code == 1
+    assert "Your API key could not be saved. Set CELESTO_API_KEY" in result.output
 
 
 def test_get_api_key_uses_saved_key_after_env_and_dotenv_miss(
@@ -93,9 +163,13 @@ def test_status_reports_missing_saved_key(monkeypatch):
 def test_logout_removes_saved_key(monkeypatch):
     runner = CliRunner()
     deleted = []
-    monkeypatch.setattr(auth, "delete_api_key", lambda base_url=None: deleted.append(base_url))
+    monkeypatch.setattr(
+        auth, "delete_api_key", lambda base_url=None: deleted.append(base_url)
+    )
 
-    result = runner.invoke(auth.app, ["logout", "--base-url", "https://api.example.test/v1"])
+    result = runner.invoke(
+        auth.app, ["logout", "--base-url", "https://api.example.test/v1"]
+    )
 
     assert result.exit_code == 0
     assert deleted == ["https://api.example.test/v1"]


### PR DESCRIPTION
Root cause: celesto auth login required keyring.set_password, which fails on Linux machines without a Secret Service or similar keyring backend.
This PR keeps OS keyring as the preferred store and falls back to an XDG config credentials file with user-only permissions when keyring is unavailable.
It also teaches load/status/logout to use the fallback, documents the Linux path, and adds regression coverage for the fallback and write-failure paths.
Validation: uv run ruff check ., uv run pytest, and a SmolVM Ubuntu smoke test of the installed package with keyring forced to fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI now persists API keys via the system credential store, with a Linux fallback to a user-only local `credentials.json` under the XDG config directory when needed.

* **Bug Fixes**
  * Login now provides clearer success messaging based on where the key was saved, and shows an actionable error when local saving fails.
  * Logout now removes saved keys from both the system store and the local fallback.

* **Documentation**
  * Updated “Get an API Key” instructions to clarify Linux persistence and how SDK authentication uses environment variables or explicitly provided values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->