### PR TITLE
Improve computer CLI stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,17 @@ with Celesto(api_key="your-api-key") as client:
 ## Manage Computers from the CLI
 
 Run these commands in a macOS or Linux shell after `celesto auth login`. The
-first command creates a computer and saves its generated name in
-`COMPUTER_NAME`. It uses Python 3 to read the JSON output.
+first command creates a computer with the default `scratch` template.
+
+```bash
+celesto computer create
+#   Name:   curie
+#   ID:     cmp_123
+#   Status: creating
+```
+
+For later examples, save the generated name in `COMPUTER_NAME`. The command
+uses `--json` so Python can read the output.
 
 ```bash
 COMPUTER_NAME=$(
@@ -102,28 +111,109 @@ COMPUTER_NAME=$(
 )
 ```
 
-Run a command in that computer:
+Inspect that computer by name or ID:
+
+```bash
+celesto computer get "$COMPUTER_NAME"
+#   Name:   curie
+#   ID:     cmp_123
+#   Status: running
+```
+
+List your computers:
+
+```bash
+celesto computer list
+```
+
+Filter the list by status:
+
+```bash
+celesto computer list --status running
+```
+
+Filter the list by template. Template IDs come from `celesto computer templates`;
+`browser-agent` is one ready-made template.
+
+```bash
+celesto computer list --template browser-agent
+```
+
+Filter the list by project. Replace `proj_123` with a project ID from your
+Celesto workspace.
+
+```bash
+celesto computer list --project proj_123
+```
+
+Limit the number of computers returned:
+
+```bash
+celesto computer list --limit 10
+```
+
+Run a command in the computer:
 
 ```bash
 celesto computer run "$COMPUTER_NAME" "uname -a"
 ```
 
-Delete the computer when you are done:
+Use a longer timeout for slow commands. The value is in seconds and must be
+between 1 and 300.
 
 ```bash
-celesto computer delete --force "$COMPUTER_NAME"
+celesto computer run "$COMPUTER_NAME" "sleep 10 && echo done" --timeout 30
 ```
 
-To open an interactive terminal, create a computer and save its name:
+Stream output while a command is still running:
 
 ```bash
-COMPUTER_NAME=$(
-  celesto computer create --json |
-  python3 -c 'import json, sys; print(json.load(sys.stdin)["name"])'
-)
+celesto computer run "$COMPUTER_NAME" "for i in 1 2 3; do echo $i; sleep 1; done" --stream
+# 1
+# 2
+# 3
 ```
 
-Connect to it:
+`celesto computer run --json` prints one JSON object for scripts and exits with
+the same exit code as the remote command. `celesto computer run --stream --json`
+prints one compact JSON event per line.
+
+Current caveat: commands run as the computer image's default exec user. The CLI
+and SDK do not yet expose a `--user` option. Run `whoami` first if your script
+depends on a specific home directory or file permission.
+
+List templates when you want a computer with tools already installed:
+
+```bash
+celesto computer templates
+```
+
+Create a computer from a template:
+
+```bash
+celesto computer create --template coding-agent
+```
+
+Publish port 8000 when a process in the computer needs a public URL:
+
+```bash
+celesto computer port publish "$COMPUTER_NAME" --port 8000
+# https://p-test.celesto.ai
+```
+
+List published ports:
+
+```bash
+celesto computer port list "$COMPUTER_NAME"
+```
+
+Unpublish the port when you are done:
+
+```bash
+celesto computer port unpublish "$COMPUTER_NAME" --port 8000
+```
+
+To open an interactive terminal, connect to the same computer:
 
 ```bash
 celesto computer ssh "$COMPUTER_NAME"
@@ -197,8 +287,13 @@ from celesto import Celesto
 with Celesto() as client:
     templates = client.computers.list_templates()
     for template in templates:
-        print(template["id"], template["default_ram_mb"])
+        print(template["id"], template.get("preinstalled_tools", []))
 ```
+
+Template responses may include metadata such as aliases, capabilities,
+preinstalled tools, recommended uses, default published ports, and browser
+support flags. Older template records may omit those fields, so use `.get()`
+when your code can run against multiple API versions.
 
 Create a computer from a template:
 
@@ -229,18 +324,59 @@ with Celesto() as client:
         client.computers.delete(computer["id"])
 ```
 
+The `timeout` value is the remote command timeout in seconds. The SDK gives the
+HTTP request a little more time than the command itself so slow command output
+can still return cleanly.
+
+Current caveat: `exec()` runs as the computer image's default exec user. The SDK
+does not yet expose a user selector.
+
 ### List, Stop, Start, and Delete
 
 `computer_id` can be the ID returned by `client.computers.create()`, such as
 `computer["id"]`, or a computer name shown by `celesto computer list`.
 
+Filter a list when you only want matching computers:
+
+```python
+from celesto import Celesto
+
+with Celesto() as client:
+    result = client.computers.list(status="running", template_id="browser-agent")
+    for computer in result["computers"]:
+        print(computer["name"])
+```
+
 | Method | What it does |
 | --- | --- |
 | `client.computers.list()` | List computers in your account |
+| `client.computers.list(status="running", template_id="browser-agent", project_id="proj_123", limit=10)` | List matching computers |
 | `client.computers.get(computer_id)` | Get one computer by name or ID |
 | `client.computers.stop(computer_id)` | Stop a running computer |
 | `client.computers.start(computer_id)` | Start a stopped computer |
 | `client.computers.delete(computer_id)` | Delete a computer |
+
+### Publish Ports
+
+Publish a port when a service inside the computer needs a public URL:
+
+```python
+from celesto import Celesto
+
+with Celesto() as client:
+    published = client.computers.publish_port("curie", port=8000)
+    print(published["url"])
+```
+
+List and remove published ports:
+
+```python
+from celesto import Celesto
+
+with Celesto() as client:
+    print(client.computers.list_published_ports("curie"))
+    client.computers.unpublish_port("curie", port=8000)
+```
 
 ## CLI Commands
 
@@ -252,8 +388,14 @@ with Celesto() as client:
 | `celesto computer create [--cpus N] [--memory MB] [--disk-size-mb MB] [--template ID]` | Create a computer |
 | `celesto computer templates` | List templates with preinstalled tools |
 | `celesto computer list` | List your computers |
-| `celesto computer run NAME "command"` | Run a command on a computer |
+| `celesto computer list [--status STATUS] [--template ID] [--project ID] [--limit N]` | List matching computers |
+| `celesto computer get NAME` | Get one computer by name or ID |
+| `celesto computer run NAME "command" [--timeout N]` | Run a command on a computer |
+| `celesto computer run NAME "command" --stream` | Stream command output while it runs |
 | `celesto computer ssh NAME` | Open an interactive terminal |
+| `celesto computer port publish NAME --port 8000` | Publish a computer port |
+| `celesto computer port list NAME` | List published ports |
+| `celesto computer port unpublish NAME --port 8000` | Unpublish a computer port |
 | `celesto computer stop NAME` | Stop a computer |
 | `celesto computer start NAME` | Start a stopped computer |
 | `celesto computer delete [--force] NAME` | Delete a computer |

--- a/src/celesto/computer.py
+++ b/src/celesto/computer.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import os
 import sys
-from typing import Optional
+import time
+from collections.abc import Iterable
+from typing import Any, Optional
 
 import typer
 from rich.console import Console
@@ -14,6 +16,7 @@ from typing_extensions import Annotated
 
 from .deployment import _get_api_key
 from .sdk.client import Celesto
+from .sdk.exceptions import CelestoServerError
 
 app = typer.Typer(help="Create, manage, and connect to sandboxed computers.")
 port_app = typer.Typer(help="Publish and unpublish computer ports.")
@@ -80,6 +83,120 @@ def _format_optional_text(value: object) -> str:
 def _print_json(data: object) -> None:
     """Print JSON to stdout (no Rich formatting)."""
     sys.stdout.write(json.dumps(data, indent=2, default=str) + "\n")
+
+
+def _print_json_line(data: object) -> None:
+    """Print one compact JSON event for streaming output."""
+    sys.stdout.write(json.dumps(data, default=str) + "\n")
+
+
+def _coerce_exit_code(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.lstrip("-").isdigit():
+        return int(value)
+    return 0
+
+
+def _print_computer_details(info: dict[str, Any]) -> None:
+    name = info.get("name", "")
+    status = str(info.get("status", ""))
+    color = _status_color(status)
+
+    console.print(f"  Name:   [bold]{name}[/bold]")
+    console.print(f"  ID:     [dim]{info.get('id', '')}[/dim]")
+    console.print(f"  Status: [{color}]{status}[/{color}]")
+    console.print(f"  CPUs:   {info.get('vcpus', 'N/A')}")
+    console.print(f"  Memory: {_format_optional_memory(info.get('ram_mb'))}")
+    console.print(f"  Disk:   {_format_optional_memory(info.get('disk_size_mb'))}")
+    console.print(f"  Template: {_format_optional_text(info.get('template_id'))}")
+    if info.get("created_at"):
+        console.print(f"  Created: {str(info.get('created_at'))[:19]}")
+
+
+def _is_stopped_conflict(error: CelestoServerError) -> bool:
+    message = str(error).lower()
+    return "stopped" in message or "409" in message
+
+
+def _resume_computer(client: Celesto, computer_id: str, *, quiet: bool = False) -> None:
+    if not quiet:
+        console.print("[yellow]Computer is stopped. Resuming...[/yellow]")
+    client.computers.start(computer_id)
+    for _ in range(30):
+        info = client.computers.get(computer_id)
+        if info.get("status") == "running":
+            break
+        time.sleep(1)
+    else:
+        if not quiet:
+            console.print("[red]Computer failed to resume.[/red]")
+        raise typer.Exit(1)
+    if not quiet:
+        console.print("[green]Computer resumed.[/green]")
+
+
+def _exec_with_resume(
+    client: Celesto,
+    computer_id: str,
+    command: str,
+    *,
+    timeout: int,
+    quiet: bool = False,
+) -> dict[str, Any]:
+    try:
+        return client.computers.exec(computer_id, command, timeout=timeout)
+    except CelestoServerError as e:
+        if not _is_stopped_conflict(e):
+            raise
+        _resume_computer(client, computer_id, quiet=quiet)
+        return client.computers.exec(computer_id, command, timeout=timeout)
+
+
+def _exec_stream_with_resume(
+    client: Celesto,
+    computer_id: str,
+    command: str,
+    *,
+    timeout: int,
+    quiet: bool = False,
+) -> Iterable[dict[str, Any]]:
+    try:
+        yield from client.computers.exec_stream(computer_id, command, timeout=timeout)
+    except CelestoServerError as e:
+        if not _is_stopped_conflict(e):
+            raise
+        _resume_computer(client, computer_id, quiet=quiet)
+        yield from client.computers.exec_stream(computer_id, command, timeout=timeout)
+
+
+def _write_stream_event(event: dict[str, Any], *, as_json: bool = False) -> int | None:
+    if as_json:
+        _print_json_line(event)
+    else:
+        wrote = False
+        stdout = event.get("stdout")
+        stderr = event.get("stderr")
+        if stdout is not None:
+            sys.stdout.write(str(stdout))
+            sys.stdout.flush()
+            wrote = True
+        if stderr is not None:
+            sys.stderr.write(str(stderr))
+            sys.stderr.flush()
+            wrote = True
+        if not wrote and "data" in event:
+            destination = (
+                sys.stderr
+                if event.get("stream") == "stderr" or event.get("type") == "stderr"
+                else sys.stdout
+            )
+            destination.write(str(event["data"]))
+            destination.flush()
+
+    if "exit_code" in event:
+        return _coerce_exit_code(event.get("exit_code"))
+    return None
 
 
 @port_app.command("publish")
@@ -217,14 +334,50 @@ def create_computer(
     console.print(f"[dim]Connect with:[/dim] celesto computer ssh {cname}")
 
 
+@app.command("get")
+def get_computer(
+    computer_id: Annotated[str, typer.Argument(help="Computer ID or name")],
+    as_json: JsonOption = False,
+    api_key: ApiKeyOption = None,
+):
+    """Get one computer by name or ID."""
+    with _get_client(api_key) as client:
+        result = client.computers.get(computer_id)
+
+    if as_json:
+        _print_json(result)
+        return
+
+    _print_computer_details(result)
+
+
 @app.command("list")
 def list_computers(
+    status: Annotated[
+        Optional[str], typer.Option("--status", help="Filter by computer status")
+    ] = None,
+    template_id: Annotated[
+        Optional[str],
+        typer.Option("--template", "--template-id", help="Filter by template ID"),
+    ] = None,
+    project_id: Annotated[
+        Optional[str],
+        typer.Option("--project", "--project-id", help="Filter by project ID"),
+    ] = None,
+    limit: Annotated[
+        Optional[int], typer.Option("--limit", min=1, help="Maximum computers to list")
+    ] = None,
     as_json: JsonOption = False,
     api_key: ApiKeyOption = None,
 ):
     """List all computers."""
     with _get_client(api_key) as client:
-        result = client.computers.list()
+        result = client.computers.list(
+            status=status,
+            template_id=template_id,
+            project_id=project_id,
+            limit=limit,
+        )
 
     computers = result.get("computers", [])
 
@@ -304,42 +457,43 @@ def run_command(
     computer_id: Annotated[str, typer.Argument(help="Computer ID or name")],
     command: Annotated[str, typer.Argument(help="Command to execute")],
     timeout: Annotated[
-        int, typer.Option("--timeout", "-t", help="Timeout in seconds")
+        int,
+        typer.Option("--timeout", "-t", min=1, max=300, help="Timeout in seconds"),
     ] = 30,
+    stream: Annotated[
+        bool, typer.Option("--stream", help="Stream output while the command runs")
+    ] = False,
     as_json: JsonOption = False,
     api_key: ApiKeyOption = None,
 ):
     """Execute a command on a computer. Automatically resumes stopped computers."""
-    import time
-
-    from .sdk.exceptions import CelestoServerError
-
     with _get_client(api_key) as client:
-        try:
-            result = client.computers.exec(computer_id, command, timeout=timeout)
-        except CelestoServerError as e:
-            if "stopped" in str(e).lower() or "409" in str(e):
-                if not as_json:
-                    console.print("[yellow]Computer is stopped. Resuming...[/yellow]")
-                client.computers.start(computer_id)
-                # Wait for it to be running
-                for _ in range(30):
-                    info = client.computers.get(computer_id)
-                    if info.get("status") == "running":
-                        break
-                    time.sleep(1)
-                else:
-                    console.print("[red]Computer failed to resume.[/red]")
-                    raise typer.Exit(1)
-                if not as_json:
-                    console.print("[green]Computer resumed.[/green]")
-                result = client.computers.exec(computer_id, command, timeout=timeout)
-            else:
-                raise
+        if stream:
+            exit_code = 0
+            events = _exec_stream_with_resume(
+                client,
+                computer_id,
+                command,
+                timeout=timeout,
+                quiet=as_json,
+            )
+            for event in events:
+                event_exit_code = _write_stream_event(event, as_json=as_json)
+                if event_exit_code is not None:
+                    exit_code = event_exit_code
+            raise typer.Exit(exit_code)
+
+        result = _exec_with_resume(
+            client,
+            computer_id,
+            command,
+            timeout=timeout,
+            quiet=as_json,
+        )
 
     if as_json:
         _print_json(result)
-        return
+        raise typer.Exit(_coerce_exit_code(result.get("exit_code")))
 
     if result.get("stdout"):
         sys.stdout.write(result["stdout"])

--- a/src/celesto/computer.py
+++ b/src/celesto/computer.py
@@ -470,6 +470,7 @@ def run_command(
     with _get_client(api_key) as client:
         if stream:
             exit_code = 0
+            saw_exit = False
             events = _exec_stream_with_resume(
                 client,
                 computer_id,
@@ -481,6 +482,17 @@ def run_command(
                 event_exit_code = _write_stream_event(event, as_json=as_json)
                 if event_exit_code is not None:
                     exit_code = event_exit_code
+                    saw_exit = True
+            if not saw_exit:
+                message = (
+                    "Command stream ended before the remote exit status was received."
+                )
+                if as_json:
+                    _print_json_line({"type": "error", "data": message})
+                else:
+                    sys.stderr.write(f"{message}\n")
+                    sys.stderr.flush()
+                exit_code = 1
             raise typer.Exit(exit_code)
 
         result = _exec_with_resume(

--- a/src/celesto/sdk/__init__.py
+++ b/src/celesto/sdk/__init__.py
@@ -11,6 +11,7 @@ from .exceptions import (
 from .types import (
     AccessRules,
     ComputerCommandHistoryEntry,
+    ComputerCommandHistoryResponse,
     ComputerConnectionInfo,
     ComputerExecResponse,
     ComputerInfo,
@@ -55,4 +56,5 @@ __all__ = [
     "ComputerListResponse",
     "ComputerExecResponse",
     "ComputerCommandHistoryEntry",
+    "ComputerCommandHistoryResponse",
 ]

--- a/src/celesto/sdk/__init__.py
+++ b/src/celesto/sdk/__init__.py
@@ -10,6 +10,7 @@ from .exceptions import (
 )
 from .types import (
     AccessRules,
+    ComputerCommandHistoryEntry,
     ComputerConnectionInfo,
     ComputerExecResponse,
     ComputerInfo,
@@ -53,4 +54,5 @@ __all__ = [
     "SandboxTemplateInfo",
     "ComputerListResponse",
     "ComputerExecResponse",
+    "ComputerCommandHistoryEntry",
 ]

--- a/src/celesto/sdk/client.py
+++ b/src/celesto/sdk/client.py
@@ -3,6 +3,7 @@ import os
 import sys
 import tarfile
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, List, Literal, Optional
 
@@ -106,6 +107,7 @@ class _BaseClient:
         json_body: dict[str, Any] | None = None,
         data: dict[str, Any] | None = None,
         files: dict[str, Any] | None = None,
+        timeout: httpx.Timeout | None = None,
     ) -> Any:
         """Make an HTTP request with proper error handling.
 
@@ -116,6 +118,7 @@ class _BaseClient:
             json_body: JSON request body
             data: Form data
             files: Files for multipart upload
+            timeout: Optional per-request timeout override
 
         Returns:
             Parsed JSON response
@@ -131,14 +134,16 @@ class _BaseClient:
         url = f"{self.base_url}{path}"
 
         try:
-            response = self.session.request(
-                method,
-                url,
-                params=params,
-                json=json_body,
-                data=data,
-                files=files,
-            )
+            request_kwargs: dict[str, Any] = {
+                "params": params,
+                "json": json_body,
+                "data": data,
+                "files": files,
+            }
+            if timeout is not None:
+                request_kwargs["timeout"] = timeout
+
+            response = self.session.request(method, url, **request_kwargs)
         except httpx.ConnectError as e:
             raise CelestoNetworkError(f"Failed to connect to Celesto API: {e}") from e
         except httpx.TimeoutException as e:
@@ -149,6 +154,59 @@ class _BaseClient:
             ) from e
 
         return self._handle_response(response)
+
+    def _stream_request(
+        self,
+        method: Literal["GET", "POST", "PUT", "DELETE"],
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        timeout: httpx.Timeout | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Stream newline-delimited JSON or SSE-style events from the API."""
+        url = f"{self.base_url}{path}"
+        request_kwargs: dict[str, Any] = {"params": params, "json": json_body}
+        if timeout is not None:
+            request_kwargs["timeout"] = timeout
+
+        try:
+            with self.session.stream(method, url, **request_kwargs) as response:
+                if response.status_code not in (200, 201, 204):
+                    response.read()
+                    self._handle_response(response)
+
+                for line in response.iter_lines():
+                    if not line:
+                        continue
+                    text = line.decode("utf-8") if isinstance(line, bytes) else line
+                    text = text.strip()
+                    if not text:
+                        continue
+                    if text.startswith("data:"):
+                        text = text.removeprefix("data:").strip()
+                    if text == "[DONE]":
+                        break
+                    try:
+                        parsed = json.loads(text)
+                    except json.JSONDecodeError:
+                        yield {"type": "stdout", "data": text}
+                        continue
+                    if isinstance(parsed, dict):
+                        yield parsed
+                    else:
+                        yield {"type": "stdout", "data": parsed}
+        except httpx.ConnectError as e:
+            raise CelestoNetworkError(f"Failed to connect to Celesto API: {e}") from e
+        except httpx.TimeoutException as e:
+            raise CelestoNetworkError(f"Request to Celesto API timed out: {e}") from e
+        except httpx.HTTPError as e:
+            raise CelestoNetworkError(
+                f"Network error while contacting Celesto API: {e}"
+            ) from e
+
+    def _timeout_with_read(self, read_timeout: int | float) -> httpx.Timeout:
+        return httpx.Timeout(connect=10, read=read_timeout, write=10, pool=10)
 
     def _handle_response(self, response: httpx.Response) -> Any:
         """Handle HTTP response and raise appropriate exceptions for errors."""
@@ -873,13 +931,36 @@ class Computers(_BaseClient):
         """
         return self._request("GET", "/computers/templates")
 
-    def list(self) -> dict[str, Any]:
+    def list(
+        self,
+        *,
+        status: str | None = None,
+        template_id: str | None = None,
+        project_id: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
         """List all computers in the current organization.
+
+        Args:
+            status: Optional status filter, such as "running" or "stopped".
+            template_id: Optional template filter, such as "coding-agent".
+            project_id: Optional project ID filter.
+            limit: Optional maximum number of computers to return.
 
         Returns:
             Dict with "computers" list and "count".
         """
-        return self._request("GET", "/computers")
+        params: dict[str, Any] = {}
+        if status is not None:
+            params["status"] = status
+        if template_id is not None:
+            params["template_id"] = template_id
+        if project_id is not None:
+            params["project_id"] = project_id
+        if limit is not None:
+            params["limit"] = limit
+
+        return self._request("GET", "/computers", params=params or None)
 
     def get(self, computer_id: str) -> dict[str, Any]:
         """Get details of a specific computer.
@@ -929,7 +1010,9 @@ class Computers(_BaseClient):
         Returns:
             Unpublished port dict.
         """
-        return self._request("DELETE", f"/computers/{computer_id}/published-ports/{port}")
+        return self._request(
+            "DELETE", f"/computers/{computer_id}/published-ports/{port}"
+        )
 
     def exec(
         self,
@@ -952,6 +1035,60 @@ class Computers(_BaseClient):
             "POST",
             f"/computers/{computer_id}/exec",
             json_body={"command": command, "timeout": timeout},
+            timeout=self._timeout_with_read(timeout + 15),
+        )
+
+    def exec_stream(
+        self,
+        computer_id: str,
+        command: str,
+        *,
+        timeout: int = 30,
+    ) -> Iterator[dict[str, Any]]:
+        """Stream command output from a running computer.
+
+        Args:
+            computer_id: Computer ID.
+            command: Shell command to execute.
+            timeout: Timeout in seconds (1-300).
+
+        Yields:
+            Stream event dicts from the backend. Events may include stdout,
+            stderr, data, stream, type, and exit_code fields.
+        """
+        return self._stream_request(
+            "POST",
+            f"/computers/{computer_id}/exec/stream",
+            json_body={"command": command, "timeout": timeout},
+            timeout=self._timeout_with_read(timeout + 15),
+        )
+
+    def list_command_history(
+        self,
+        computer_id: str,
+        *,
+        limit: int | None = None,
+    ) -> Any:
+        """List prior commands for a computer.
+
+        This wraps the existing backend command-history endpoint without adding
+        a new CLI shape.
+
+        Args:
+            computer_id: Computer ID or name.
+            limit: Optional maximum number of history entries to return.
+
+        Returns:
+            Backend command-history payload.
+        """
+        params: dict[str, Any] = {}
+        if limit is not None:
+            params["limit"] = limit
+
+        return self._request(
+            "GET",
+            f"/computers/{computer_id}/commands",
+            params=params or None,
         )
 
     def stop(self, computer_id: str) -> dict[str, Any]:

--- a/src/celesto/sdk/types.py
+++ b/src/celesto/sdk/types.py
@@ -200,16 +200,24 @@ class ComputerExecResponse(TypedDict):
 class ComputerCommandHistoryEntry(TypedDict):
     """A prior command execution for a computer."""
 
-    id: NotRequired[str]
-    computer_id: NotRequired[str]
-    command: str
-    status: NotRequired[str]
-    exit_code: NotRequired[int | None]
-    stdout: NotRequired[str | None]
-    stderr: NotRequired[str | None]
-    created_at: NotRequired[str | None]
+    command_id: str
+    source: str
+    status: str
     started_at: NotRequired[str | None]
-    completed_at: NotRequired[str | None]
+    ended_at: NotRequired[str | None]
+    duration_ms: NotRequired[int | None]
+    timeout_seconds: NotRequired[int | None]
+    exit_code: NotRequired[int | None]
+    stdout_bytes: NotRequired[int | None]
+    stderr_bytes: NotRequired[int | None]
+    error_type: NotRequired[str | None]
+
+
+class ComputerCommandHistoryResponse(TypedDict):
+    """Response from listing prior command executions."""
+
+    commands: List[ComputerCommandHistoryEntry]
+    count: int
 
 
 # ============================================================================
@@ -238,4 +246,5 @@ __all__ = [
     "ComputerListResponse",
     "ComputerExecResponse",
     "ComputerCommandHistoryEntry",
+    "ComputerCommandHistoryResponse",
 ]

--- a/src/celesto/sdk/types.py
+++ b/src/celesto/sdk/types.py
@@ -173,6 +173,13 @@ class SandboxTemplateInfo(TypedDict):
     default_disk_size_mb: int
     version: NotRequired[str | None]
     experimental: bool
+    aliases: NotRequired[List[str]]
+    capabilities: NotRequired[List[str]]
+    preinstalled_tools: NotRequired[List[str]]
+    recommended_for: NotRequired[List[str]]
+    default_published_ports: NotRequired[List[int]]
+    has_playwright_browsers: NotRequired[bool]
+    has_browser_system_deps: NotRequired[bool]
 
 
 class ComputerListResponse(TypedDict):
@@ -188,6 +195,21 @@ class ComputerExecResponse(TypedDict):
     exit_code: int
     stdout: str
     stderr: str
+
+
+class ComputerCommandHistoryEntry(TypedDict):
+    """A prior command execution for a computer."""
+
+    id: NotRequired[str]
+    computer_id: NotRequired[str]
+    command: str
+    status: NotRequired[str]
+    exit_code: NotRequired[int | None]
+    stdout: NotRequired[str | None]
+    stderr: NotRequired[str | None]
+    created_at: NotRequired[str | None]
+    started_at: NotRequired[str | None]
+    completed_at: NotRequired[str | None]
 
 
 # ============================================================================
@@ -215,4 +237,5 @@ __all__ = [
     "SandboxTemplateInfo",
     "ComputerListResponse",
     "ComputerExecResponse",
+    "ComputerCommandHistoryEntry",
 ]

--- a/tests/test_computer_cli.py
+++ b/tests/test_computer_cli.py
@@ -220,6 +220,19 @@ def test_computer_run_stream_routes_stderr_events_to_stderr(monkeypatch):
     assert result.stderr == "warn\n"
 
 
+def test_computer_run_stream_fails_when_exit_event_is_missing(monkeypatch):
+    runner = CliRunner()
+    fake_client = _FakeClient()
+    fake_client.computers.stream_events = [{"type": "stdout", "data": "partial\n"}]
+    monkeypatch.setattr(computer, "_get_client", lambda api_key=None: fake_client)
+
+    result = runner.invoke(computer.app, ["run", "curie", "partial", "--stream"])
+
+    assert result.exit_code == 1
+    assert result.stdout == "partial\n"
+    assert "ended before the remote exit status" in result.stderr
+
+
 def test_computer_run_rejects_timeout_outside_allowed_range(monkeypatch):
     runner = CliRunner()
     fake_client = _FakeClient()

--- a/tests/test_computer_cli.py
+++ b/tests/test_computer_cli.py
@@ -21,7 +21,53 @@ def test_terminal_dimensions_return_rows_then_columns(monkeypatch):
 
 class _FakeComputers:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, str, int | None]] = []
+        self.calls: list[tuple] = []
+        self.exec_exit_code = 0
+        self.stream_events = [
+            {"stdout": "streamed\n"},
+            {"exit_code": 0},
+        ]
+
+    @staticmethod
+    def _computer_payload(name: str = "curie") -> dict:
+        return {
+            "id": "cmp_123",
+            "name": name,
+            "status": "running",
+            "vcpus": 1,
+            "ram_mb": 1024,
+            "disk_size_mb": 7168,
+            "image": "ubuntu-desktop-24.04",
+            "template_id": "scratch",
+            "created_at": "2026-06-07T00:00:00Z",
+        }
+
+    def list(
+        self,
+        *,
+        status: str | None = None,
+        template_id: str | None = None,
+        project_id: str | None = None,
+        limit: int | None = None,
+    ) -> dict:
+        self.calls.append(("list", status, template_id, project_id, limit))
+        return {"computers": [self._computer_payload()], "count": 1}
+
+    def get(self, computer_id: str) -> dict:
+        self.calls.append(("get", computer_id))
+        return self._computer_payload(name=computer_id)
+
+    def exec(self, computer_id: str, command: str, *, timeout: int = 30) -> dict:
+        self.calls.append(("exec", computer_id, command, timeout))
+        return {
+            "exit_code": self.exec_exit_code,
+            "stdout": "ok\n",
+            "stderr": "",
+        }
+
+    def exec_stream(self, computer_id: str, command: str, *, timeout: int = 30):
+        self.calls.append(("exec_stream", computer_id, command, timeout))
+        yield from self.stream_events
 
     def publish_port(self, computer_id: str, *, port: int = 8000) -> dict:
         self.calls.append(("publish", computer_id, port))
@@ -84,6 +130,105 @@ def test_computer_port_publish_prints_url(monkeypatch):
             urls.append(parsed)
     assert any(u.scheme == "https" and u.hostname == "p-test.celesto.ai" for u in urls)
     assert fake_client.computers.calls == [("publish", "curie", 8000)]
+
+
+def test_computer_get_json(monkeypatch):
+    runner = CliRunner()
+    fake_client = _FakeClient()
+    monkeypatch.setattr(computer, "_get_client", lambda api_key=None: fake_client)
+
+    result = runner.invoke(computer.app, ["get", "curie", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["id"] == "cmp_123"
+    assert payload["name"] == "curie"
+    assert fake_client.computers.calls == [("get", "curie")]
+
+
+def test_computer_list_passes_filters_to_sdk(monkeypatch):
+    runner = CliRunner()
+    fake_client = _FakeClient()
+    monkeypatch.setattr(computer, "_get_client", lambda api_key=None: fake_client)
+
+    result = runner.invoke(
+        computer.app,
+        [
+            "list",
+            "--status",
+            "running",
+            "--template",
+            "browser-agent",
+            "--project",
+            "proj_123",
+            "--limit",
+            "5",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload[0]["name"] == "curie"
+    assert fake_client.computers.calls == [
+        ("list", "running", "browser-agent", "proj_123", 5)
+    ]
+
+
+def test_computer_run_json_exits_with_remote_exit_code(monkeypatch):
+    runner = CliRunner()
+    fake_client = _FakeClient()
+    fake_client.computers.exec_exit_code = 7
+    monkeypatch.setattr(computer, "_get_client", lambda api_key=None: fake_client)
+
+    result = runner.invoke(computer.app, ["run", "curie", "false", "--json"])
+
+    assert result.exit_code == 7
+    payload = json.loads(result.output)
+    assert payload["exit_code"] == 7
+    assert fake_client.computers.calls == [("exec", "curie", "false", 30)]
+
+
+def test_computer_run_stream_invokes_sdk_method_and_prints_output(monkeypatch):
+    runner = CliRunner()
+    fake_client = _FakeClient()
+    monkeypatch.setattr(computer, "_get_client", lambda api_key=None: fake_client)
+
+    result = runner.invoke(
+        computer.app,
+        ["run", "curie", "printf hello", "--stream", "--timeout", "45"],
+    )
+
+    assert result.exit_code == 0
+    assert "streamed\n" in result.output
+    assert fake_client.computers.calls == [("exec_stream", "curie", "printf hello", 45)]
+
+
+def test_computer_run_stream_routes_stderr_events_to_stderr(monkeypatch):
+    runner = CliRunner()
+    fake_client = _FakeClient()
+    fake_client.computers.stream_events = [
+        {"type": "stderr", "data": "warn\n"},
+        {"type": "exit", "exit_code": 0},
+    ]
+    monkeypatch.setattr(computer, "_get_client", lambda api_key=None: fake_client)
+
+    result = runner.invoke(computer.app, ["run", "curie", "warn", "--stream"])
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert result.stderr == "warn\n"
+
+
+def test_computer_run_rejects_timeout_outside_allowed_range(monkeypatch):
+    runner = CliRunner()
+    fake_client = _FakeClient()
+    monkeypatch.setattr(computer, "_get_client", lambda api_key=None: fake_client)
+
+    result = runner.invoke(computer.app, ["run", "curie", "echo ok", "--timeout", "0"])
+
+    assert result.exit_code != 0
+    assert fake_client.computers.calls == []
 
 
 def test_computer_port_publish_json(monkeypatch):

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -10,6 +10,7 @@ class DummySession:
         self.status_code = status_code
         self.payload = payload if payload is not None else {}
         self.calls = []
+        self.timeout = httpx.Timeout(connect=10, read=120, write=10, pool=10)
 
     def request(self, method, url, **kwargs):
         self.calls.append({"method": method, "url": url, **kwargs})
@@ -108,6 +109,71 @@ def test_computers_list_templates_hits_backend_endpoint():
     assert session.calls[0]["url"] == "https://api.example.test/v1/computers/templates"
 
 
+def test_computers_list_preserves_default_unfiltered_request():
+    session = DummySession(payload={"computers": [], "count": 0})
+    client = Celesto("test-key", base_url="https://api.example.test/v1")
+    client.session = session
+
+    result = client.computers.list()
+
+    assert result["count"] == 0
+    assert session.calls[0]["method"] == "GET"
+    assert session.calls[0]["url"] == "https://api.example.test/v1/computers"
+    assert session.calls[0]["params"] is None
+
+
+def test_computers_list_sends_filters_as_query_params():
+    session = DummySession(payload={"computers": [], "count": 0})
+    client = Celesto("test-key", base_url="https://api.example.test/v1")
+    client.session = session
+
+    client.computers.list(
+        status="running",
+        template_id="browser-agent",
+        project_id="proj_123",
+        limit=5,
+    )
+
+    assert session.calls[0]["params"] == {
+        "status": "running",
+        "template_id": "browser-agent",
+        "project_id": "proj_123",
+        "limit": 5,
+    }
+
+
+def test_computers_exec_uses_per_request_read_timeout_without_mutating_default():
+    session = DummySession(payload={"exit_code": 0, "stdout": "ok\n", "stderr": ""})
+    client = Celesto("test-key", base_url="https://api.example.test/v1")
+    client.session = session
+
+    result = client.computers.exec("cmp_123", "sleep 1", timeout=60)
+
+    assert result["stdout"] == "ok\n"
+    assert (
+        session.calls[0]["url"] == "https://api.example.test/v1/computers/cmp_123/exec"
+    )
+    assert session.calls[0]["json"] == {"command": "sleep 1", "timeout": 60}
+    assert session.calls[0]["timeout"].read == 75
+    assert session.timeout.read == 120
+
+
+def test_computers_list_command_history_hits_backend_endpoint():
+    session = DummySession(payload={"commands": []})
+    client = Celesto("test-key", base_url="https://api.example.test/v1")
+    client.session = session
+
+    result = client.computers.list_command_history("cmp_123", limit=10)
+
+    assert result == {"commands": []}
+    assert session.calls[0]["method"] == "GET"
+    assert (
+        session.calls[0]["url"]
+        == "https://api.example.test/v1/computers/cmp_123/commands"
+    )
+    assert session.calls[0]["params"] == {"limit": 10}
+
+
 def test_computers_publish_port_hits_backend_endpoint():
     session = DummySession(
         payload={
@@ -126,7 +192,10 @@ def test_computers_publish_port_hits_backend_endpoint():
 
     assert result["url"] == "https://p-test.celesto.ai"
     assert session.calls[0]["method"] == "POST"
-    assert session.calls[0]["url"] == "https://api.example.test/v1/computers/curie/published-ports"
+    assert (
+        session.calls[0]["url"]
+        == "https://api.example.test/v1/computers/curie/published-ports"
+    )
     assert session.calls[0]["json"] == {"port": 8000}
 
 
@@ -139,7 +208,10 @@ def test_computers_list_published_ports_hits_backend_endpoint():
 
     assert result == []
     assert session.calls[0]["method"] == "GET"
-    assert session.calls[0]["url"] == "https://api.example.test/v1/computers/cmp_123/published-ports"
+    assert (
+        session.calls[0]["url"]
+        == "https://api.example.test/v1/computers/cmp_123/published-ports"
+    )
 
 
 def test_computers_unpublish_port_hits_backend_endpoint():
@@ -159,4 +231,7 @@ def test_computers_unpublish_port_hits_backend_endpoint():
 
     assert result["status"] == "unpublished"
     assert session.calls[0]["method"] == "DELETE"
-    assert session.calls[0]["url"] == "https://api.example.test/v1/computers/cmp_123/published-ports/8000"
+    assert (
+        session.calls[0]["url"]
+        == "https://api.example.test/v1/computers/cmp_123/published-ports/8000"
+    )


### PR DESCRIPTION
## Summary
- add `celesto computer get`, filtered `computer list`, and `computer run --stream`
- make buffered exec use a per-request HTTP read timeout of command timeout + 15s
- expose additive template metadata types and SDK command history wrapper
- document computer create/get/list/run/templates/ports and the current exec-user caveat

## Tests
- `uv run pytest`
- `uv run ruff check src/celesto tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing a single computer, filtering computer lists, and running commands with streaming output and timeout controls.
  * Added command history access and expanded port publishing, listing, and unpublishing capabilities.
  * Improved template details shown in Python examples with more useful metadata.

* **Documentation**
  * Expanded CLI and Python SDK guides with clearer examples for creating, listing, connecting to, and managing computers.
  * Updated command reference to cover the new list, get, run, and port-related options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->