### PR TITLE
Release SDK v0.0.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,5 +68,15 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Check published npm version
+        id: npm-version
+        run: |
+          if npm view "@celestoai/sdk@$(node -p "require('./package.json').version")" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
+        if: steps.npm-version.outputs.exists != 'true'
         run: npm publish --access public

--- a/src/celesto/__init__.py
+++ b/src/celesto/__init__.py
@@ -3,6 +3,6 @@
 from .main import app
 from .sdk import Celesto
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 __all__ = ["app", "Celesto", "__version__"]


### PR DESCRIPTION
## Summary
- bump Python SDK/CLI package version to 0.0.7
- skip npm publish when the unchanged JS package version is already published

## Verification
- uv run pytest tests/test_sdk.py tests/test_computer_cli.py tests/test_auth.py tests/test_deployment.py
- uv run ruff check src/celesto tests
- UV_CACHE_DIR=/private/tmp/uv-cache uv build
- npm ci && npm run lint && npm test && npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate package publishes by skipping release if the same version is already available.
* **Chores**
  * Updated the package version to **0.0.7**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->