### PR TITLE
Release SDK v0.0.8

### DIFF
--- a/src/celesto/__init__.py
+++ b/src/celesto/__init__.py
@@ -3,6 +3,6 @@
 from .main import app
 from .sdk import Celesto
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 __all__ = ["app", "Celesto", "__version__"]

--- a/src/celesto/sdk/client.py
+++ b/src/celesto/sdk/client.py
@@ -920,6 +920,7 @@ class Computers(_BaseClient):
             "POST",
             "/computers",
             json_body=payload,
+            timeout=self._timeout_with_read(600),
         )
 
     def list_templates(self) -> list[dict[str, Any]]:

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -62,6 +62,8 @@ def test_computers_create_sends_only_explicit_overrides():
         "disk_size_mb": 15360,
         "template_id": "coding-agent",
     }
+    assert session.calls[0]["timeout"].read == 600
+    assert session.timeout.read == 120
 
 
 def test_computers_create_with_no_args_uses_backend_defaults():


### PR DESCRIPTION
## Summary
- bump Python SDK/CLI to 0.0.8
- give computer create a 10-minute per-request read timeout while preserving the default client timeout
- add a regression assertion for create timeout behavior

## Why
Live smoke with published 0.0.7 showed browser-agent create can exceed the default 120s HTTP read timeout and leave the backend-created computer running/creating without returning an id to the CLI.

## Verification
- UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/test_sdk.py tests/test_computer_cli.py tests/test_auth.py tests/test_deployment.py
- UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check src/celesto tests
- UV_CACHE_DIR=/private/tmp/uv-cache uv build