### PR TITLE
Release SDK v0.0.9

### DIFF
--- a/src/celesto/__init__.py
+++ b/src/celesto/__init__.py
@@ -3,6 +3,6 @@
 from .main import app
 from .sdk import Celesto
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 __all__ = ["app", "Celesto", "__version__"]

--- a/src/celesto/sdk/client.py
+++ b/src/celesto/sdk/client.py
@@ -20,6 +20,10 @@ from .exceptions import (
 )
 
 _BASE_URL = os.environ.get("CELESTO_BASE_URL", "https://api.celesto.ai/v1")
+# Deployed proxies can terminate long idle buffered exec responses before the
+# backend command timeout. Aggregate the existing streaming endpoint for longer
+# commands while preserving the public exec() return shape.
+_STREAM_EXEC_FOR_TIMEOUT_OVER_SECONDS = 110
 
 
 class _BaseConnection:
@@ -1032,12 +1036,83 @@ class Computers(_BaseClient):
         Returns:
             Dict with exit_code, stdout, stderr.
         """
+        if timeout > _STREAM_EXEC_FOR_TIMEOUT_OVER_SECONDS:
+            return self._exec_via_stream(
+                computer_id,
+                command,
+                timeout=timeout,
+            )
+
         return self._request(
             "POST",
             f"/computers/{computer_id}/exec",
             json_body={"command": command, "timeout": timeout},
             timeout=self._timeout_with_read(timeout + 15),
         )
+
+    def _exec_via_stream(
+        self,
+        computer_id: str,
+        command: str,
+        *,
+        timeout: int,
+    ) -> dict[str, Any]:
+        stdout_parts: list[str] = []
+        stderr_parts: list[str] = []
+        exit_code: int | None = None
+        duration_ms: int | None = None
+        timed_out: bool | None = None
+        command_id: str | None = None
+
+        for event in self.exec_stream(computer_id, command, timeout=timeout):
+            if command_id is None and isinstance(event.get("command_id"), str):
+                command_id = event["command_id"]
+
+            if event.get("stdout") is not None:
+                stdout_parts.append(str(event["stdout"]))
+            if event.get("stderr") is not None:
+                stderr_parts.append(str(event["stderr"]))
+
+            event_type = event.get("type")
+            if event_type == "stdout":
+                stdout_parts.append(str(event.get("data", "")))
+            elif event_type == "stderr":
+                stderr_parts.append(str(event.get("data", "")))
+
+            if "exit_code" in event:
+                raw_exit_code = event.get("exit_code")
+                if isinstance(raw_exit_code, int):
+                    exit_code = raw_exit_code
+                elif (
+                    isinstance(raw_exit_code, str)
+                    and raw_exit_code.lstrip("-").isdigit()
+                ):
+                    exit_code = int(raw_exit_code)
+                else:
+                    exit_code = 1
+                raw_duration_ms = event.get("duration_ms")
+                if isinstance(raw_duration_ms, int):
+                    duration_ms = raw_duration_ms
+                if "timed_out" in event:
+                    timed_out = bool(event.get("timed_out"))
+
+        if exit_code is None:
+            raise CelestoServerError(
+                "Command stream ended before the remote exit status was received."
+            )
+
+        result: dict[str, Any] = {
+            "exit_code": exit_code,
+            "stdout": "".join(stdout_parts),
+            "stderr": "".join(stderr_parts),
+        }
+        if command_id is not None:
+            result["command_id"] = command_id
+        if duration_ms is not None:
+            result["duration_ms"] = duration_ms
+        if timed_out is not None:
+            result["timed_out"] = timed_out
+        return result
 
     def exec_stream(
         self,

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -160,6 +160,40 @@ def test_computers_exec_uses_per_request_read_timeout_without_mutating_default()
     assert session.timeout.read == 120
 
 
+def test_computers_exec_aggregates_stream_for_long_timeouts(monkeypatch):
+    session = DummySession(payload={"exit_code": 0, "stdout": "buffered\n"})
+    client = Celesto("test-key", base_url="https://api.example.test/v1")
+    client.session = session
+    stream_calls = []
+
+    def fake_exec_stream(computer_id: str, command: str, *, timeout: int = 30):
+        stream_calls.append((computer_id, command, timeout))
+        yield {"type": "stdout", "data": "hello\n"}
+        yield {"type": "stderr", "data": "warn\n"}
+        yield {
+            "type": "exit",
+            "exit_code": "7",
+            "duration_ms": 123,
+            "timed_out": False,
+            "command_id": "cmd_123",
+        }
+
+    monkeypatch.setattr(client.computers, "exec_stream", fake_exec_stream)
+
+    result = client.computers.exec("cmp_123", "sleep 130", timeout=300)
+
+    assert result == {
+        "exit_code": 7,
+        "stdout": "hello\n",
+        "stderr": "warn\n",
+        "command_id": "cmd_123",
+        "duration_ms": 123,
+        "timed_out": False,
+    }
+    assert stream_calls == [("cmp_123", "sleep 130", 300)]
+    assert session.calls == []
+
+
 def test_computers_list_command_history_hits_backend_endpoint():
     session = DummySession(payload={"commands": []})
     client = Celesto("test-key", base_url="https://api.example.test/v1")


### PR DESCRIPTION
## Summary
- bump Python SDK/CLI to 0.0.9
- aggregate the existing streaming exec endpoint for long Computers.exec calls while preserving the buffered return shape
- add a regression test proving long exec avoids the buffered endpoint

## Why
Live smoke with 0.0.8 confirmed browser-agent create/get/list/stream/json behavior, but a 130s buffered command returned a backend 502 from the synchronous buffered path. Long exec now uses the deployed streaming endpoint preemptively instead of retrying after a failed buffered call, avoiding duplicate command execution and preserving CLI/SDK output shape.

## Verification
- UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/test_sdk.py tests/test_computer_cli.py tests/test_auth.py tests/test_deployment.py
- UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check src/celesto tests
- UV_CACHE_DIR=/private/tmp/uv-cache uv build